### PR TITLE
For macOS drag'n'drop checks whether SDL2 is newer than 2.0.14 (becau…

### DIFF
--- a/Exult_Removal_of_X11_Connection_Number.md
+++ b/Exult_Removal_of_X11_Connection_Number.md
@@ -1,0 +1,60 @@
+# Removal of X11 ConnectionNumber xfd in Exult
+December 2020 by Dragon Baroque.
+
+## Analysis
+
+The X11 `ConnectionNumber` is a Unix file descriptor used deep in the SDL Event Loop to be notified of incoming X11 User events.
+Exult used also the file descriptor as part of a timed `select` call in two places :
+
+1. `gumps/gump_util.h`, function `Delay()`. The purpose of the `Delay()` function, which might more properly have been named `Yield(),`
+was to create a short duration - 20 to 50 milliseconds - timed out wait, using a `select` UNIX call that would complete either at the end of
+the timeout or upon an incoming X11 event, whichever occurred first. The function was written to use the `xfd` X11 file descriptor
+and the `select` call in the `XWIN` configuration. In the `_WIN32` configuration however, the same `Delay()` function performed
+a simple `SDL_Delay(10)` for a pure 10 milliseconds wait with no heed to incoming user events.
+2. `server/server.cc`, function `Server_delay()`. Very similar to `Delay()` in the `XWIN` configuration, but with the UNIX sockets
+for an incoming connection or message from ExultSudio added to `xfd` in the `select` call.
+
+The advantage of the X11 file descriptor `xfd` is its ability to be part of a `select` statement, which a boolean returning C function cannot be.
+Its problem is that it ties the non Windows platforms to use X11, and that is becoming a burden :
+
+* The `macOS` platform is a kind of Unix, but its system graphics is not X11, it is Quartz, and they are quite different.
+One can install an Open Source package called `XQuartz` over Quartz to obtain a X11 compatibility layer, but it causes a performance penalty.
+* The Linux platform is moving away from X11 towards Wayland, and while the X11 stack is probably remaining in the Linux distributions for some time,
+the Wayland stack claims better performance.
+* It might be nice to have one source code only without any platform specifics for these two services in all platforms, Windows included.
+
+## Proposal
+
+I propose to replace each function `Delay()` and `Server_delay()` by a ten turns - to be more reactive - or fifty turns - to respect the 50 milliseconds
+original design - of a loop with two actions :
+
+1. A call to `SDL_PumpEvents()` to refresh the SDL Event Queue followed immediately by a `SDL_PeepEvents()` fo check whether any SDL Event has shown up on
+the Event Queue. It is deep in `SDL_PumpEvents()` that SDL itself makes use of the X11 file descriptor.
+2. A simple `SDL_Delay(1)` for a 1 millisecond wait, deaf to incoming Events, for `Delay()`, or a `select` call over the ExultStudio sockets, timed out at
+1 millisecond, for `Server_delay()`, which would terminate upon an incoming connection or message from ExultStudio, *but not a X11 event*.
+
+My main reason for this proposal is the increase of precision of the hardware timers and the increase of power in the CPUs.
+Indeed, high precision hardware timers based delays should incur very little drift even at the minimum scale of 1 millisecond supported by SDL.
+
+## State of the code change
+
+* `studio.cc` : The declaration of and the assignment to `xfd` are removed.
+* `gumps/gump_util.h` : The function `Delay()` does not depend on the configuration, it uses the same loop of pure SDL calls `SDL_PumpEvents`, `SDL_PeepEvents`
+and `SDL_Delay` on all platforms.
+* `server/server.cc` : The function `Server_delay()` in the `not _WIN32` configuration is rewritten to use the loop of `SDL_PumpEvents`, `SDL_PeepEvents` and
+UNIX `select`. The function `Set_highest_fd` does not use `xfd` any more.
+
+The code change compiles under Linux. It should compile under macOS and under Windows.
+The code change runs under Linux with no visible performance penalty, nor any visible CPU load increase. The latest could have been expected, considering that
+the code change replaces a simple 10 or 50 millisecond wait by an active loop for 10 milliseconds that awakens and performs some work every 1 millisecond.
+
+## Side notice
+
+The `XWIN` configuration variable seems to have two different meanings :
+
+1. A broad meaning of *Any platform Unix-like*, where its complement is `_WIN32`,
+2. A narrow meaning of *Any Unix-like platform whose system graphics is X11*.
+
+MacOS using Quartz is sitting uneasily on the boundary between the two meanings, and Linux using Wayland shall be soon.
+
+Dragon Baroque, December 26, 2020.

--- a/Exult_Removal_of_X11_Drag_and_Drop.md
+++ b/Exult_Removal_of_X11_Drag_and_Drop.md
@@ -1,0 +1,73 @@
+# Removal of X11 Drag and Drop xdnd in Exult
+January 2021 by Dragon Baroque.
+
+## Analysis
+
+The Drag and Drop between ExultStudio and Exult uses a specialized X11 code in the receiver part in Exult on all Unix platforms.
+
+On Windows platforms, Exult also contains an OLE Drag and Drop, that could also be unified into the framework presented in the current
+document. This has not been evaluated, however. Moreover, the emitting part of the Drag and Drop in ExultStudio also contains a Windows
+specialized variant, whose purpose is not evaluated either.
+
+The use of X11 as the Drag and Drop protocol on Unix platforms forces the installation of the X11 emulator `XQuartz` as a prerequisite
+to the installation of Exult packaged with ExultStudio on macOS. This is the requirement that this work attempts to remove.
+
+Likewise, Linux platforms are moving away from X11 toward Wayland, and the X11 dependency from the Drag and Drop is a longer range
+constraint to be removed.
+
+## Proposal
+
+SDL, the graphical application layer used by Exult - whereas ExultStudio uses GTK+ -, contains a very limited support of the Drag and Drop.
+Limited, but powerful enough to justify the current proposal of removing the X11 specific code for the Drag and Drop in Exult and use the
+SDL Drag and Drop instead.
+
+SDL provides only `SDL_DROPFILE` as the Drag and Drop on all platforms. On X11 platforms only, it also provides `SDL_DROPTEXT`.
+Thus `SDL_DROPFILE` has been chosen as the Drag and Drop medium for the communication between ExultStudio and Exult, and to avoid having
+two different protocols in ExultStudio, for the internal Drag and Drop of ExultStudio too.
+
+`SDL_DROPFILE` is a pure application of the Drag and Drop between, say, a File Explorer, and an SDL application. The user Drags a file from
+the File Explorer into the SDL application. It uses the well-known target `text/uri-list`. Technically, and fortunately for Exult,
+only the file identity is transferred, its existence is not even checked. Provided that ExultStudio can encode its data into an artificial
+but valid file name, ExultStudio can emit its Drag and Drop data to the `text/uri-list` target, and the Exult and ExultStudio receivers
+can extract the Dragged object data from the file name.
+
+The use of `SDL_DROPFILE` has the obvious advantage of removing the need for an X11 specialized code - and should be checked for the
+opportunity of removing the Windows specialized code, too - but it has several drawbacks :
+
+1. Only the Drop event of the Drag and Drop protocol is reported to Exult. Whereas GTK+ also reports the Mouse Drag Motion events, too.
+And the present X11 specialized code also handled the Mouse Drag Motion events, to provide a green grid to help the user to fine position
+the dragged shape before actually dropping it.
+2. The ExultStudio internal Drag and Drop as well as the ExultStudio to Exult Drag and Drop defined 4 targets, for the 4 different kind
+of items that can be Dragged and Dropped, namely the NPCs, the Chunks, the Combos, and the regular Shapes. The `SDL_DROPFILE` uses only
+one and well-known target `text/uri-file`. The code of ExultStudio has been altered along this requirement. But the single target delays
+the acceptation or the rejection of a Shape into a dedicated Shape window - for example the Face and Body icons of the NPC Editor window -
+until the user actually drops the Shape into the window.
+3. The `SDL_DROPFILE` Drop event does not provide the mouse location. This is reasonable considering the actual purpose of the Drag and
+Drop of files. Thus the `SDL_DROPFILE` event has to obtain the mouse current location to complete the Drop operation - to create a new
+NPC or Chunk or Combo or Shape at the right place within the display window of the game.
+
+## State of the code change
+
+* `Makefile.am` : `xdrag.h` and `xdrag.cc` are no longer sources to be compiled and linked to Exult.
+* `studio.cc` : The declaration of and the assignment to `xdnd` are removed. The handling of the `SYS_WMEVENT` events is removed.
+The `SDL_DROPFILE` is handled, with a handling code borrowed from `xdrag.cc`, with the additional requirement of recognizing from
+the data - thus from the file name - which of the 4 kinds of objects it has to handle.
+* `shapes/u7drag.h` and `shapes/u7drag.cc` : The binary data marshalling is replaced by a `file name compatible` data marshalling.
+Essentially, the artificial file name built for the `SDL_DROPFILE` is like **file:///U7SHAPEID._filenum_._shapenum_._framenum_** where
+where the first token of the file name designates the kind of Dropped object, and each subsequent number is appended in decimal,
+signed if needed, behind a separation dot.
+Since the target no longer designates the kind of Dropped object, functions have been added to detect the kind of Dropped object
+from the file name.
+* `mapedit/chunklst.cc`, `mapedit/combo.cc`,`mapedit/npclst.cc`,`mapedit/shapedraw.cc` and `mapedit/shapelst.cc` : The Drag and Drop
+target names have been replaced by the generic target name `text/uri-list`. However the `info` field is kept with its kind of object
+specific value. This permits an early detection of the kind of object for the Drag and Drop receivers in ExultStudio. This feature
+depends on the proper support of the `info` field on all platforms : _to be properly checked_. The size of the artificial file name
+is computed from a C macro provided by `u7drag.h`. All internal Drag and Drop receivers double check the proper kind of Dropped object
+using the new functions in `u7drag.cc`.
+
+The code change compiles under Linux. It should compile under macOS. It should be evaluated for use under Windows too.
+
+The code change runs under Linux, with X11 as the backend, with no apparent unexpected effect of the target name change, on all paths
+of the Drag and Drop that I could test.
+
+Dragon Baroque, January 2, 2021.

--- a/Makefile.am
+++ b/Makefile.am
@@ -103,9 +103,7 @@ exult_SOURCES =	\
 	txtscroll.cc	\
 	txtscroll.h	\
 	version.cc	\
-	version.h	\
-	xdrag.cc	\
-	xdrag.h
+	version.h
 
 if BUILD_MT32EMU
 EXTRA_EXULTLIBS=audio/midi_drivers/mt32emu/libmt32emu.la

--- a/configure.ac
+++ b/configure.ac
@@ -534,19 +534,27 @@ if test "$WINDOWING_SYSTEM" != -DXWIN -a "$WINDOWING_SYSTEM" != -D_WIN32 ; then
 	enable_exult_studio_support=no
 fi
 
-AC_ARG_ENABLE(macosx-studio-support, AS_HELP_STRING([--enable-macosx-studio-support], [Force ExultStudio support in Mac OS X @<:@EXPERIMENTAL@:>@ @<:@default no@:>@]),,enable_macosx_studio_support=no)
+AC_ARG_ENABLE(macosx-x11-studio-support, AS_HELP_STRING([--enable-macosx-x11-studio-support], [Force Exult Studio X11 support in Mac OS X @<:@default no@:>@]),,enable_macosx_x11_studio_support=no)
 if test "$WINDOWING_SYSTEM" != -DMACOSX; then
-	enable_macosx_studio_support=no
+	enable_macosx_x11_studio_support=no
 fi
 
-if test x$enable_macosx_studio_support = xyes ; then
+if test x$enable_macosx_x11_studio_support = xyes ; then
 	enable_exult_studio_support=yes
+	SYSLIBS="$SYSLIBS -L/usr/X11R6/lib -lX11"
+	AC_DEFINE(XWIN, 1, [X11 (needed by Exult Studio X11 support in macOS)])
 fi
 
 if test x$enable_exult_studio_support = xyes ; then
 	AC_MSG_RESULT(yes)
 	AC_DEFINE(USE_EXULTSTUDIO, 1, [Use Exult Studio])
-	
+	AC_CHECK_FUNC(xwin, AC_DEFINE(XWIN))
+	if test "$WINDOWING_SYSTEM" = -DMACOSX -a "$ac_cv_func_xwin" != yes; then
+		if test ! $sdl_patchlevel -gt "14"; then
+			as_fn_error $? "*** SDL2 2.0.15 or newer is needed or use --enable-macosx-x11-studio-support!" "$LINENO" 5
+		fi
+	fi
+
 	# due to bug 2129731 and 3139441 some Linux distributions need -lX11 explicitly set 
 	# when enabling Exult Studio support or linking fails
 	if test "$WINDOWING_SYSTEM" = -DXWIN ; then

--- a/configure.ac
+++ b/configure.ac
@@ -541,8 +541,6 @@ fi
 
 if test x$enable_macosx_studio_support = xyes ; then
 	enable_exult_studio_support=yes
-	SYSLIBS="$SYSLIBS -L/usr/X11R6/lib -lX11"
-	AC_DEFINE(XWIN, 1, [X11 (needed by Exult Studio support in Mac OS X)])
 fi
 
 if test x$enable_exult_studio_support = xyes ; then

--- a/exult.cc
+++ b/exult.cc
@@ -191,10 +191,6 @@ int current_scaleval = 1;
 #  pragma GCC diagnostic ignored "-Wold-style-cast"
 #  endif  // __GNUC__
 
-int xfd = 0;            // X connection #.
-static inline int WrappedConnectionNumber(Display *display) {
-	return ConnectionNumber(display);
-}
 #ifdef USE_EXULTSTUDIO
 static class Xdnd *xdnd = nullptr;
 #endif
@@ -906,7 +902,6 @@ static void Init(
 #ifdef USE_EXULTSTUDIO
 #ifndef _WIN32
 	SDL_GetWindowWMInfo(gwin->get_win()->get_screen_window(), &info);
-	xfd = WrappedConnectionNumber(info.info.x11.display);
 	Server_init();          // Initialize server (for map-editor).
 	xdnd = new Xdnd(info.info.x11.display, info.info.x11.window,
 	                info.info.x11.window,

--- a/exult.cc
+++ b/exult.cc
@@ -42,8 +42,6 @@
 #endif
 #ifdef _WIN32
 #include "windrag.h"
-#elif defined(XWIN)
-// #include "xdrag.h" Removed : Use SDL_DROPFILE
 #endif
 #include "servemsg.h"
 #include "objserial.h"
@@ -190,10 +188,6 @@ int current_scaleval = 1;
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wold-style-cast"
 #  endif  // __GNUC__
-
-#ifdef USE_EXULTSTUDIO
-//static class Xdnd *xdnd = nullptr; Removed : Use SDL_DROPFILE
-#endif
 
 #  ifdef __GNUC__
 #  pragma GCC diagnostic pop
@@ -597,8 +591,6 @@ int exult_main(const char *runpath) {
 #if defined(_WIN32)
 	RevokeDragDrop(hgwin);
 	windnd->Release();
-#else
-//	delete xdnd; Removed : Use SDL_DROPFILE
 #endif
 	Server_close();
 #endif
@@ -894,11 +886,6 @@ static void Init(
 #ifndef _WIN32
 	SDL_GetWindowWMInfo(gwin->get_win()->get_screen_window(), &info);
 	Server_init();          // Initialize server (for map-editor).
-//	xdnd = new Xdnd(info.info.x11.display, info.info.x11.window,
-//	                info.info.x11.window,
-//	                Move_dragged_shape, Move_dragged_combo,
-//	                Drop_dragged_shape, Drop_dragged_chunk,
-//	                Drop_dragged_npc, Drop_dragged_combo);
 	SDL_EventState(SDL_DROPFILE, SDL_ENABLE);
 #else
 	SDL_GetWindowWMInfo(gwin->get_win()->get_screen_window(), &info);

--- a/exult.cc
+++ b/exult.cc
@@ -717,10 +717,7 @@ static void Init(
 	std::atexit(SDL_Quit);
 
 	SDL_SysWMinfo info;     // Get system info.
-#ifdef USE_EXULTSTUDIO
-	// Want drag-and-drop events.
-	SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
-#endif
+
 	// KBD repeat should be nice.
 	SDL_ShowCursor(0);
 	SDL_VERSION(&info.version);

--- a/exult.cc
+++ b/exult.cc
@@ -698,6 +698,10 @@ static void Init(
 #endif
 #ifdef _WIN32
 	SDL_putenv("SDL_AUDIODRIVER=DirectSound");
+#elif defined(MACOSX) && defined(XWIN) && defined(USE_EXULTSTUDIO)
+	// Exult Studio drag'n'drop with SDL2 < 2.0.15 requires Exult
+	// to use X11. Hence, we force the issue.
+	SDL_putenv("SDL_VIDEODRIVER=x11");
 #endif
 	SDL_SetHint(SDL_HINT_ORIENTATIONS, "Landscape");
 #if 0

--- a/gumps/gump_utils.h
+++ b/gumps/gump_utils.h
@@ -19,42 +19,28 @@
 #ifndef GUMP_UTILS_H
 #define GUMP_UTILS_H
 
-#ifdef XWIN  /* Only needed in XWIN. */
-#include <sys/time.h>
-#endif
-
-#ifdef OPENBSD
-#include <sys/types.h>
-#endif
-
 #include <unistd.h>
 
-#ifndef XWIN
 #include "SDL_timer.h"
-#endif
+#include "SDL_events.h"
 
 /*
  *  Delay between animations.
  */
 
+#define DELAY_TOTAL_MS 10
+#define DELAY_SINGLE_MS 1
+
 inline void Delay(
 ) {
-#ifdef XWIN
-	/*
-	 *  Here's a somewhat better way to delay in X:
-	 */
-	extern int xfd;
-	fd_set rfds;
-	struct timeval timer;
-	timer.tv_sec = 0;
-	timer.tv_usec = 50000;      // Try 1/50 second.
-	FD_ZERO(&rfds);
-	FD_SET(xfd, &rfds);
-	// Wait for timeout or event.
-	select(xfd + 1, &rfds, nullptr, nullptr, &timer);
-#else                   /* May use this for Linux too. */
-	SDL_Delay(10);          // Try 1/100 second.
-#endif
+	Uint32 expiration = DELAY_TOTAL_MS + SDL_GetTicks();
+	for (;;) {
+		SDL_PumpEvents();
+		if ((SDL_PeepEvents(nullptr, 0, SDL_PEEKEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT) != 0) ||
+		    (static_cast<Sint32>(SDL_GetTicks()) >= static_cast<Sint32>(expiration))) return;
+
+		SDL_Delay(DELAY_SINGLE_MS);
+	}
 }
 
 #endif

--- a/mapedit/combo.cc
+++ b/mapedit/combo.cc
@@ -960,7 +960,9 @@ void Combo_chooser::drag_data_get(
     gpointer data           // ->Shape_chooser.
 ) {
 	ignore_unused_variable_warning(widget, context, time);
-	cout << "In DRAG_DATA_GET" << endl;
+	cout << "In DRAG_DATA_GET of Combo for '"
+	     << gdk_atom_name(gtk_selection_data_get_target(seldata))
+	     << "'" << endl;
 	auto *chooser = static_cast<Combo_chooser *>(data);
 	if (chooser->selected < 0 || info != U7_TARGET_COMBOID)
 		return;         // Not sure about this.
@@ -969,7 +971,7 @@ void Combo_chooser::drag_data_get(
 	Combo *combo = chooser->combos[num];
 	// Get enough memory.
 	int cnt = combo->members.size();
-	int buflen = 5 * 4 + cnt * 5 * 4;
+	int buflen = U7DND_DATA_LENGTH(5 + cnt * 5);
 	cout << "Buflen = " << buflen << endl;
 	auto *buf = new unsigned char[buflen];
 	auto *ents = new U7_combo_data[cnt];
@@ -994,7 +996,7 @@ void Combo_chooser::drag_data_get(
 #else
 	// Set data.
 	gtk_selection_data_set(seldata,
-	                       gdk_atom_intern(U7_TARGET_COMBOID_NAME, 0),
+	                       gtk_selection_data_get_target(seldata),
 	                       8, buf, len);
 #endif
 	delete [] buf;
@@ -1011,7 +1013,7 @@ gint Combo_chooser::drag_begin(
     gpointer data           // ->Combo_chooser.
 ) {
 	ignore_unused_variable_warning(widget);
-	cout << "In DRAG_BEGIN" << endl;
+	cout << "In DRAG_BEGIN of Combo" << endl;
 	auto *chooser = static_cast<Combo_chooser *>(data);
 	if (chooser->selected < 0)
 		return FALSE;       // ++++Display a halt bitmap.

--- a/mapedit/npclst.cc
+++ b/mapedit/npclst.cc
@@ -529,11 +529,13 @@ void Npc_chooser::drag_data_get(
     gpointer data           // ->Npc_chooser.
 ) {
 	ignore_unused_variable_warning(widget, context, time);
-	cout << "In DRAG_DATA_GET" << endl;
+	cout << "In DRAG_DATA_GET of Npc for '"
+	     << gdk_atom_name(gtk_selection_data_get_target(seldata))
+	     << "'" << endl;
 	auto *chooser = static_cast<Npc_chooser *>(data);
 	if (chooser->selected < 0 || info != U7_TARGET_NPCID)
 		return;         // Not sure about this.
-	guchar buf[30];
+	guchar buf[U7DND_DATA_LENGTH(1)];
 	int npcnum = chooser->info[chooser->selected].npcnum;
 	int len = Store_u7_npcid(buf, npcnum);
 	cout << "Setting selection data (" << npcnum << ')' << endl;
@@ -543,7 +545,7 @@ void Npc_chooser::drag_data_get(
 #else
 	// Set data.
 	gtk_selection_data_set(seldata,
-	                       gdk_atom_intern(U7_TARGET_NPCID_NAME, 0),
+	                       gtk_selection_data_get_target(seldata),
 	                       8, buf, len);
 #endif
 }
@@ -558,7 +560,7 @@ gint Npc_chooser::drag_begin(
     gpointer data           // ->Npc_chooser.
 ) {
 	ignore_unused_variable_warning(widget);
-	cout << "In DRAG_BEGIN" << endl;
+	cout << "In DRAG_BEGIN of Npc" << endl;
 	auto *chooser = static_cast<Npc_chooser *>(data);
 	if (chooser->selected < 0)
 		return FALSE;       // ++++Display a halt bitmap.
@@ -588,8 +590,13 @@ void Npc_chooser::drag_data_received(
 ) {
 	ignore_unused_variable_warning(widget, context, x, y, info, time);
 	auto *chooser = static_cast<Npc_chooser *>(udata);
-	cout << "Npc drag_data_received" << endl;
-	if (gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_NPCID_NAME, 0) &&
+	cout << "In DRAG_DATA_RECEIVED of Npc for '"
+	     << gdk_atom_name(gtk_selection_data_get_data_type(seldata))
+	     << "'" << endl;
+	if ((gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_NPCID_NAME, 0) ||
+	     gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_GENERIC_NAME_X11, 0) ||
+	     gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_GENERIC_NAME_MACOSX, 0)) &&
+	        Is_u7_npcid(gtk_selection_data_get_data(seldata)) == true &&
 	        gtk_selection_data_get_format(seldata) == 8 &&
 	        gtk_selection_data_get_length(seldata) > 0) {
 		int npcnum;
@@ -611,11 +618,17 @@ void Npc_chooser::enable_drop(
 	drop_enabled = true;
 	gtk_widget_realize(draw);//???????
 #ifndef _WIN32
-	GtkTargetEntry tents[1];
+	GtkTargetEntry tents[3];
 	tents[0].target = const_cast<char *>(U7_TARGET_NPCID_NAME);
+	tents[1].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_X11);
+	tents[2].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_MACOSX);
 	tents[0].flags = 0;
+	tents[1].flags = 0;
+	tents[2].flags = 0;
 	tents[0].info = U7_TARGET_NPCID;
-	gtk_drag_dest_set(draw, GTK_DEST_DEFAULT_ALL, tents, 1,
+	tents[1].info = U7_TARGET_NPCID;
+	tents[2].info = U7_TARGET_NPCID;
+	gtk_drag_dest_set(draw, GTK_DEST_DEFAULT_ALL, tents, 3,
 	                  static_cast<GdkDragAction>(GDK_ACTION_COPY | GDK_ACTION_MOVE));
 
 	g_signal_connect(G_OBJECT(draw), "drag-data-received",

--- a/mapedit/paledit.cc
+++ b/mapedit/paledit.cc
@@ -357,7 +357,7 @@ gint Palette_edit::drag_begin(
     gpointer data           // ->Palette_edit.
 ) {
 	ignore_unused_variable_warning(widget, context, data);
-	cout << "In DRAG_BEGIN" << endl;
+	cout << "In DRAG_BEGIN of Palette" << endl;
 	//Palette_edit *paled = static_cast<Palette_edit *>(data);
 	// Maybe someday.
 	return TRUE;

--- a/mapedit/shapedraw.cc
+++ b/mapedit/shapedraw.cc
@@ -224,9 +224,14 @@ void Shape_draw::drag_data_received(
 ) {
 	ignore_unused_variable_warning(widget, context, x, y, info, time);
 	auto *draw = static_cast<Shape_draw *>(udata);
-	cout << "drag_data_received" << endl;
+	cout << "In DRAG_DATA_RECEIVED of Shape for '"
+	     << gdk_atom_name(gtk_selection_data_get_data_type(seldata))
+	     << "'" << endl;
 	if (draw->drop_callback &&
-	        gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_SHAPEID_NAME, 0) &&
+	        (gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_SHAPEID_NAME, 0) ||
+	         gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_GENERIC_NAME_X11, 0) ||
+	         gtk_selection_data_get_data_type(seldata) == gdk_atom_intern(U7_TARGET_GENERIC_NAME_MACOSX, 0)) &&
+	        Is_u7_shapeid(gtk_selection_data_get_data(seldata)) == true &&
 	        gtk_selection_data_get_format(seldata) == 8 &&
 	        gtk_selection_data_get_length(seldata) > 0) {
 		int file;
@@ -250,11 +255,17 @@ void Shape_draw::enable_drop(
 #ifndef _WIN32
 	drop_callback = callback;
 	drop_user_data = udata;
-	GtkTargetEntry tents[1];
+	GtkTargetEntry tents[3];
 	tents[0].target = const_cast<char *>(U7_TARGET_SHAPEID_NAME);
+	tents[1].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_X11);
+	tents[2].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_MACOSX);
 	tents[0].flags = 0;
+	tents[1].flags = 0;
+	tents[2].flags = 0;
 	tents[0].info = U7_TARGET_SHAPEID;
-	gtk_drag_dest_set(draw, GTK_DEST_DEFAULT_ALL, tents, 1,
+	tents[1].info = U7_TARGET_SHAPEID;
+	tents[2].info = U7_TARGET_SHAPEID;
+	gtk_drag_dest_set(draw, GTK_DEST_DEFAULT_ALL, tents, 3,
 	                  static_cast<GdkDragAction>(GDK_ACTION_COPY | GDK_ACTION_MOVE));
 
 	g_signal_connect(G_OBJECT(draw), "drag-data-received",
@@ -313,11 +324,17 @@ void Shape_draw::start_drag(
 	if (dragging)
 		return;
 	dragging = true;
-	GtkTargetEntry tents[1];// Set up for dragging.
+	GtkTargetEntry tents[3];// Set up for dragging.
 	tents[0].target = const_cast<char *>(target);
+	tents[1].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_X11);
+	tents[2].target = const_cast<char *>(U7_TARGET_GENERIC_NAME_MACOSX);
 	tents[0].flags = 0;
+	tents[1].flags = 0;
+	tents[2].flags = 0;
 	tents[0].info = id;
-	GtkTargetList *tlist = gtk_target_list_new(&tents[0], 1);
+	tents[1].info = id;
+	tents[2].info = id;
+	GtkTargetList *tlist = gtk_target_list_new(&tents[0], 3);
 	// ??+++ Do we need to free tlist?
 	gtk_drag_begin_with_coordinates(draw, tlist,
 	                                static_cast<GdkDragAction>(GDK_ACTION_COPY | GDK_ACTION_MOVE),

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -587,7 +587,7 @@ gint Shape_chooser::drag_motion(
 	ignore_unused_variable_warning(widget);
 	auto *chooser = static_cast<Shape_chooser *>(data);
 	if (!chooser->dragging && chooser->selected >= 0)
-		chooser->start_drag(U7_TARGET_GENERIC_NAME,
+		chooser->start_drag(U7_TARGET_SHAPEID_NAME,
 		                    U7_TARGET_SHAPEID, reinterpret_cast<GdkEvent *>(event));
 	return true;
 }
@@ -1743,7 +1743,9 @@ void Shape_chooser::drag_data_get(
     gpointer data           // ->Shape_chooser.
 ) {
 	ignore_unused_variable_warning(widget, context, time);
-	cout << "In DRAG_DATA_GET" << endl;
+	cout << "In DRAG_DATA_GET of Shape for '"
+	     << gdk_atom_name(gtk_selection_data_get_target(seldata))
+	     << "'" << endl;
 	auto *chooser = static_cast<Shape_chooser *>(data);
 	if (chooser->selected < 0 || info != U7_TARGET_SHAPEID)
 		return;         // Not sure about this.
@@ -1762,7 +1764,7 @@ void Shape_chooser::drag_data_get(
 #else
 	// Set data.
 	gtk_selection_data_set(seldata,
-	                       gdk_atom_intern(U7_TARGET_GENERIC_NAME, 0),
+	                       gtk_selection_data_get_target(seldata),
 	                       8, buf, len);
 #endif
 }
@@ -1777,7 +1779,7 @@ gint Shape_chooser::drag_begin(
     gpointer data           // ->Shape_chooser.
 ) {
 	ignore_unused_variable_warning(widget);
-	cout << "In DRAG_BEGIN" << endl;
+	cout << "In DRAG_BEGIN of Shape" << endl;
 	auto *chooser = static_cast<Shape_chooser *>(data);
 	if (chooser->selected < 0)
 		return FALSE;       // ++++Display a halt bitmap.

--- a/mapedit/shapelst.cc
+++ b/mapedit/shapelst.cc
@@ -587,7 +587,7 @@ gint Shape_chooser::drag_motion(
 	ignore_unused_variable_warning(widget);
 	auto *chooser = static_cast<Shape_chooser *>(data);
 	if (!chooser->dragging && chooser->selected >= 0)
-		chooser->start_drag(U7_TARGET_SHAPEID_NAME,
+		chooser->start_drag(U7_TARGET_GENERIC_NAME,
 		                    U7_TARGET_SHAPEID, reinterpret_cast<GdkEvent *>(event));
 	return true;
 }
@@ -1747,7 +1747,7 @@ void Shape_chooser::drag_data_get(
 	auto *chooser = static_cast<Shape_chooser *>(data);
 	if (chooser->selected < 0 || info != U7_TARGET_SHAPEID)
 		return;         // Not sure about this.
-	guchar buf[30];
+	guchar buf[U7DND_DATA_LENGTH(3)];
 	int file = chooser->ifile->get_u7drag_type();
 	if (file == U7_SHAPE_UNK)
 		file = U7_SHAPE_SHAPES; // Just assume it's shapes.vga.
@@ -1762,7 +1762,7 @@ void Shape_chooser::drag_data_get(
 #else
 	// Set data.
 	gtk_selection_data_set(seldata,
-	                       gdk_atom_intern(U7_TARGET_SHAPEID_NAME, 0),
+	                       gdk_atom_intern(U7_TARGET_GENERIC_NAME, 0),
 	                       8, buf, len);
 #endif
 }

--- a/shapes/u7drag.cc
+++ b/shapes/u7drag.cc
@@ -31,145 +31,210 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "utils.h"
 
 /*
- *  Store in char array.
+ *  Store a Shape : file, shape, frame.
  *
- *  Output: Length of what's stored.
+ *  Output: Length of data.
  */
 
 int Store_u7_shapeid(
-    unsigned char *data,        // At least 4 bytes.
-    int file,           // 0-255.
-    int shape,          // 0-0xffff.
-    int frame           // 0-255.
+    unsigned char *data,
+    int file,             // 0-0xff.
+    int shape,            // 0-0xffff.
+    int frame             // 0-0xff.
 ) {
-	unsigned char *ptr = data;
-	*ptr++ = file;
-	Write2(ptr, shape);
-	*ptr++ = frame;
-	return ptr - data;
+	return 1 + snprintf(reinterpret_cast<char *>(data), U7DND_DATA_LENGTH(3),
+	                    "file:///%s.%d.%d.%d", U7_TARGET_SHAPEID_NAME, file, shape, frame);
 }
 
 /*
- *  Retrieve shapeid.
+ *  Retrieve a Shape : file, shape, frame.
  */
 
 void Get_u7_shapeid(
-    const unsigned char *data,        // At least 4 bytes.
-    int &file,          // 0-255.
-    int &shape,         // 0-0xffff.
-    int &frame          // 0-255.
+    const unsigned char *data,
+    int &file,            // 0-0xff.
+    int &shape,           // 0-0xffff.
+    int &frame            // 0-0xff.
 ) {
-	const unsigned char *ptr = data;
-	file = *ptr++;
-	shape = Read2(ptr);
-	frame = *ptr;
+	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	const char *ptr = strchr(reinterpret_cast<const char *>(data), '.');
+	sscanf(ptr, ".%d.%d.%d", &file, &shape, &frame);
 }
 
 /*
- *  Store/retrieve chunk #.
+ *  Check a Shape.
+ */
+
+int Is_u7_shapeid(
+    const unsigned char *data
+) {
+	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	const unsigned char *dot  = reinterpret_cast<const unsigned char *>(
+	    strchr(reinterpret_cast<const char *>(data), '.'));
+	if (dot == nullptr) return false;
+	int len = dot - data;
+	if (strncmp(reinterpret_cast<const char *>(data), U7_TARGET_SHAPEID_NAME, len) == 0)
+		return true;
+	return false;
+}
+
+/*
+ *  Store a Chunk : chunk.
  *
- *  Output: Length of what's stored.
+ *  Output: Length of data.
  */
 
 int Store_u7_chunkid(
-    unsigned char *data,        // At least 4 bytes.
-    int cnum            // Chunk #.
+    unsigned char *data,
+    int cnum              // 0-0xffff.
 ) {
-	unsigned char *ptr = data;
-	Write2(ptr, cnum);
-	return ptr - data;
-}
-
-void Get_u7_chunkid(
-    const unsigned char *data,        // At least 4 bytes.
-    int &cnum           // 0-0xffff returned.
-) {
-	const unsigned char *ptr = data;
-	cnum = Read2(ptr);
+	return 1 + snprintf(reinterpret_cast<char *>(data), U7DND_DATA_LENGTH(1),
+	                    "file:///%s.%d", U7_TARGET_CHUNKID_NAME, cnum);
 }
 
 /*
- *  Store/retrieve npc #.
+ *  Retrieve a Chunk : chunk.
+ */
+
+void Get_u7_chunkid(
+    const unsigned char *data,
+    int &cnum             // 0-0xffff.
+) {
+	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	const char *ptr = strchr(reinterpret_cast<const char *>(data), '.');
+	sscanf(ptr, ".%d", &cnum);
+}
+
+/*
+ *  Check a Chunk.
+ */
+
+int Is_u7_chunkid(
+    const unsigned char *data
+) {
+	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	const unsigned char *dot  = reinterpret_cast<const unsigned char *>(
+	    strchr(reinterpret_cast<const char *>(data), '.'));
+	if (dot == nullptr) return false;
+	int len = dot - data;
+	if (strncmp(reinterpret_cast<const char *>(data), U7_TARGET_CHUNKID_NAME, len) == 0)
+		return true;
+	return false;
+}
+
+/*
+ *  Store an NPC : npc.
  *
- *  Output: Length of what's stored.
+ *  Output: Length of data.
  */
 
 int Store_u7_npcid(
-    unsigned char *data,        // At least 4 bytes.
-    int npcnum          // Npc #.
+    unsigned char *data,
+    int npcnum            // 0-0xffff.
 ) {
-	unsigned char *ptr = data;
-	Write2(ptr, npcnum);
-	return ptr - data;
-}
-
-void Get_u7_npcid(
-    const unsigned char *data,        // At least 4 bytes.
-    int &npcnum         // 0-0xffff returned.
-) {
-	const unsigned char *ptr = data;
-	npcnum = Read2(ptr);
+	return 1 + snprintf(reinterpret_cast<char *>(data), U7DND_DATA_LENGTH(1),
+	                    "file:///%s.%d", U7_TARGET_NPCID_NAME, npcnum);
 }
 
 /*
- *  Store combo.
+ *  Retrieve an NPC.
+ */
+
+void Get_u7_npcid(
+    const unsigned char *data,
+    int &npcnum           // 0-0xffff.
+) {
+	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	const char *ptr = strchr(reinterpret_cast<const char *>(data), '.');
+	sscanf(ptr, ".%d", &npcnum);
+}
+
+/*
+ *  Check an NPC.
+ */
+
+int Is_u7_npcid(
+    const unsigned char *data
+) {
+	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	const unsigned char *dot  = reinterpret_cast<const unsigned char *>(
+	    strchr(reinterpret_cast<const char *>(data), '.'));
+	if (dot == nullptr) return false;
+	int len = dot - data;
+	if (strncmp(reinterpret_cast<const char *>(data), U7_TARGET_NPCID_NAME, len) == 0)
+		return true;
+	return false;
+}
+
+/*
+ *  Store a Combo : x, y, right, below tiles, count of shapes -> each shape : x, y, z, shape, frame.
  *
- *  Output: Length of data stored.
+ *  Output: Length of data.
  */
 
 int Store_u7_comboid(
     unsigned char *data,
-    int xtiles, int ytiles,     // Footprint in tiles.
-    int tiles_right,        // Tiles to right of hot-spot.
-    int tiles_below,        // Tiles below hot-spot.
-    int cnt,            // # members.
-    U7_combo_data *ents     // The members, with locs. relative to
-    //   hot-spot.
+    int xtiles,           // 0-0xffff : X - Footprint in tiles.
+    int ytiles,           // 0-0xffff : Y - Footprint in tiles.
+    int tiles_right,      // 0-0xffff : Tiles to the right of the hot-spot.
+    int tiles_below,      // 0-0xffff : Tiles below the hot-spot.
+    int cnt,              // 0-0xffff : Number of members.
+    U7_combo_data *ents   // The members, with locations relative - can be negative - to hot-spot.
 ) {
-	unsigned char *ptr = data;
-	Write2(ptr, xtiles);
-	Write2(ptr, ytiles);
-	Write2(ptr, tiles_right);
-	Write2(ptr, tiles_below);
-	Write2(ptr, cnt);
+	unsigned char *ptr = data + snprintf(reinterpret_cast<char *>(data), U7DND_DATA_LENGTH(5),
+	                                     "file:///%s.%d.%d.%d.%d.%d", U7_TARGET_COMBOID_NAME,
+	                                     xtiles, ytiles, tiles_right, tiles_below, cnt);
 	for (int i = 0; i < cnt; i++) {
-		Write2(ptr, ents[i].tx);
-		Write2(ptr, ents[i].ty);
-		Write2(ptr, ents[i].tz);
-		Write2(ptr, ents[i].shape);
-		*ptr++ = static_cast<unsigned char>(ents[i].frame);
+		ptr = ptr + snprintf(reinterpret_cast<char *>(ptr),
+		                     U7DND_DATA_LENGTH(5+(5*cnt)) - (ptr - data),
+		                     ".%d.%d.%d.%d.%d",
+		                     ents[i].tx, ents[i].ty, ents[i].tz, ents[i].shape, ents[i].frame);
 	}
-	return ptr - data;
+	return ptr + 1 - data;
 }
 
 /*
- *  Retrieve a combo.
+ *  Retrieve a Combo : x, y, right, below tiles, count of shapes -> each shape : x, y, z, shape, frame.
  *
- *  Output: cnt = #elements.
- *      ents = ALLOCATED array of shapes with offsets rel. to hot-spot.
+ *  Output: cnt  = count of shapes.
+ *          ents = Allocated array of shapes with offsets relative to hot-spot.
  */
 
 void Get_u7_comboid(
     const unsigned char *data,
-    int &xtiles, int &ytiles,   // Footprint in tiles.
-    int &tiles_right,       // Tiles to right of hot-spot.
-    int &tiles_below,       // Tiles below hot-spot.
-    int &cnt,
-    U7_combo_data  *&ents
+    int &xtiles,          // 0-0xffff : X - Footprint in tiles.
+    int &ytiles,          // 0-0xffff : Y - Footprint in tiles.
+    int &tiles_right,     // 0-0xffff : Tiles to the right of the hot-spot.
+    int &tiles_below,     // 0-0xffff : Tiles below the hot-spot.
+    int &cnt,             // 0-0xffff : Number of members.
+    U7_combo_data *&ents  // The members, with locations relative - can be negative - to hot-spot.
 ) {
-	const unsigned char *ptr = data;
-	xtiles = Read2(ptr);
-	ytiles = Read2(ptr);
-	tiles_right = Read2(ptr);
-	tiles_below = Read2(ptr);
-	cnt = Read2(ptr);
+	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	const char *ptr = strchr(reinterpret_cast<const char *>(data), '.');
+	int n;
+	sscanf(ptr, ".%d.%d.%d.%d.%d%n", &xtiles, &ytiles, &tiles_right, &tiles_below, &cnt, &n);
+	ptr += n;
 	ents = new U7_combo_data[cnt];
 	for (int i = 0; i < cnt; i++) {
-		// Tiles can be negative!
-		ents[i].tx = static_cast<short>(Read2(ptr));
-		ents[i].ty = static_cast<short>(Read2(ptr));
-		ents[i].tz = static_cast<short>(Read2(ptr));
-		ents[i].shape = Read2(ptr);
-		ents[i].frame = *ptr++;
+		sscanf(ptr, ".%d.%d.%d.%d.%d%n",
+		       &ents[i].tx, &ents[i].ty, &ents[i].tz, &ents[i].shape, &ents[i].frame, &n);
+		ptr += n;
 	}
+}
+
+/*
+ *  Check a Combo.
+ */
+
+int Is_u7_comboid(
+    const unsigned char *data
+) {
+	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	const unsigned char *dot  = reinterpret_cast<const unsigned char *>(
+	    strchr(reinterpret_cast<const char *>(data), '.'));
+	if (dot == nullptr) return false;
+	int len = dot - data;
+	if (strncmp(reinterpret_cast<const char *>(data), U7_TARGET_COMBOID_NAME, len) == 0)
+		return true;
+	return false;
 }

--- a/shapes/u7drag.cc
+++ b/shapes/u7drag.cc
@@ -56,7 +56,7 @@ void Get_u7_shapeid(
     int &shape,           // 0-0xffff.
     int &frame            // 0-0xff.
 ) {
-	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	if (memcmp(data, "file:///", strlen("file:///")) == 0) data += strlen("file:///"); else if (data[0] == '/') data++;
 	const char *ptr = strchr(reinterpret_cast<const char *>(data), '.');
 	sscanf(ptr, ".%d.%d.%d", &file, &shape, &frame);
 }
@@ -68,7 +68,7 @@ void Get_u7_shapeid(
 int Is_u7_shapeid(
     const unsigned char *data
 ) {
-	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	if (memcmp(data, "file:///", strlen("file:///")) == 0) data += strlen("file:///"); else if (data[0] == '/') data++;
 	const unsigned char *dot  = reinterpret_cast<const unsigned char *>(
 	    strchr(reinterpret_cast<const char *>(data), '.'));
 	if (dot == nullptr) return false;
@@ -100,7 +100,7 @@ void Get_u7_chunkid(
     const unsigned char *data,
     int &cnum             // 0-0xffff.
 ) {
-	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	if (memcmp(data, "file:///", strlen("file:///")) == 0) data += strlen("file:///"); else if (data[0] == '/') data++;
 	const char *ptr = strchr(reinterpret_cast<const char *>(data), '.');
 	sscanf(ptr, ".%d", &cnum);
 }
@@ -112,7 +112,7 @@ void Get_u7_chunkid(
 int Is_u7_chunkid(
     const unsigned char *data
 ) {
-	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	if (memcmp(data, "file:///", strlen("file:///")) == 0) data += strlen("file:///"); else if (data[0] == '/') data++;
 	const unsigned char *dot  = reinterpret_cast<const unsigned char *>(
 	    strchr(reinterpret_cast<const char *>(data), '.'));
 	if (dot == nullptr) return false;
@@ -144,7 +144,7 @@ void Get_u7_npcid(
     const unsigned char *data,
     int &npcnum           // 0-0xffff.
 ) {
-	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	if (memcmp(data, "file:///", strlen("file:///")) == 0) data += strlen("file:///"); else if (data[0] == '/') data++;
 	const char *ptr = strchr(reinterpret_cast<const char *>(data), '.');
 	sscanf(ptr, ".%d", &npcnum);
 }
@@ -156,7 +156,7 @@ void Get_u7_npcid(
 int Is_u7_npcid(
     const unsigned char *data
 ) {
-	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	if (memcmp(data, "file:///", strlen("file:///")) == 0) data += strlen("file:///"); else if (data[0] == '/') data++;
 	const unsigned char *dot  = reinterpret_cast<const unsigned char *>(
 	    strchr(reinterpret_cast<const char *>(data), '.'));
 	if (dot == nullptr) return false;
@@ -209,7 +209,7 @@ void Get_u7_comboid(
     int &cnt,             // 0-0xffff : Number of members.
     U7_combo_data *&ents  // The members, with locations relative - can be negative - to hot-spot.
 ) {
-	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	if (memcmp(data, "file:///", strlen("file:///")) == 0) data += strlen("file:///"); else if (data[0] == '/') data++;
 	const char *ptr = strchr(reinterpret_cast<const char *>(data), '.');
 	int n;
 	sscanf(ptr, ".%d.%d.%d.%d.%d%n", &xtiles, &ytiles, &tiles_right, &tiles_below, &cnt, &n);
@@ -229,7 +229,7 @@ void Get_u7_comboid(
 int Is_u7_comboid(
     const unsigned char *data
 ) {
-	if (memcmp(data, "file:///", 8) == 0) data += 8; else if (data[0] == '/') data++;
+	if (memcmp(data, "file:///", strlen("file:///")) == 0) data += strlen("file:///"); else if (data[0] == '/') data++;
 	const unsigned char *dot  = reinterpret_cast<const unsigned char *>(
 	    strchr(reinterpret_cast<const char *>(data), '.'));
 	if (dot == nullptr) return false;

--- a/shapes/u7drag.h
+++ b/shapes/u7drag.h
@@ -30,7 +30,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //	  Prefix = 18 : 8 file:/// + 9 U7CHUNKID + 1 terminating null
 #define U7DND_DATA_LENGTH(n) (18 + ((n)*7))
 //	Generic FILE_MIME Target
-#define U7_TARGET_GENERIC_NAME "text/uri-list"
+#define U7_TARGET_GENERIC_NAME_X11    "text/uri-list"
+#define U7_TARGET_GENERIC_NAME_MACOSX "public.file-url"
 
 //	Target information for dragging a shape:
 #define U7_TARGET_SHAPEID_NAME "U7SHAPEID"

--- a/shapes/u7drag.h
+++ b/shapes/u7drag.h
@@ -25,6 +25,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef INCL_U7DRAG
 #define INCL_U7DRAG 1
 
+//	Generic Data Length is :
+//	  Per number = 7 : 1 dot separator + 1 sign + 5 digits
+//	  Prefix = 18 : 8 file:/// + 9 U7CHUNKID + 1 terminating null
+#define U7DND_DATA_LENGTH(n) (18 + ((n)*7))
+//	Generic FILE_MIME Target
+#define U7_TARGET_GENERIC_NAME "text/uri-list"
+
 //	Target information for dragging a shape:
 #define U7_TARGET_SHAPEID_NAME "U7SHAPEID"
 #define U7_TARGET_SHAPEID 137
@@ -41,6 +48,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //	Store/get shapeid.
 int Store_u7_shapeid(unsigned char *data, int file, int shape, int frame);
 void Get_u7_shapeid(const unsigned char *data, int &file, int &shape, int &frame);
+int Is_u7_shapeid(const unsigned char *data);
 
 //	Target information for dragging a chunk:
 #define U7_TARGET_CHUNKID_NAME "U7CHUNKID"
@@ -49,6 +57,7 @@ void Get_u7_shapeid(const unsigned char *data, int &file, int &shape, int &frame
 //	Store/get chunk #.
 int Store_u7_chunkid(unsigned char *data, int cnum);
 void Get_u7_chunkid(const unsigned char *data, int &cnum);
+int Is_u7_chunkid(const unsigned char *data);
 
 //	Target information for dragging an npc:
 #define U7_TARGET_NPCID_NAME "U7NPCID"
@@ -57,6 +66,7 @@ void Get_u7_chunkid(const unsigned char *data, int &cnum);
 //	Store/get npc #.
 int Store_u7_npcid(unsigned char *data, int npcnum);
 void Get_u7_npcid(const unsigned char *data, int &npcnum);
+int Is_u7_npcid(const unsigned char *data);
 
 //	Target information for dragging a 'combo' (group of shapes):
 #define U7_TARGET_COMBOID_NAME "U7COMBOID"
@@ -70,6 +80,7 @@ int Store_u7_comboid(unsigned char *data, int xtiles, int ytiles,
                      int tiles_right, int tiles_below, int cnt, U7_combo_data *ents);
 void Get_u7_comboid(const unsigned char *data, int &xtiles, int &ytiles,
                     int &tiles_right, int &tiles_below, int &cnt, U7_combo_data  *&ents);
+int Is_u7_comboid(const unsigned char *data);
 
 // Put these here since they are shared between XWin and Win32
 


### PR DESCRIPTION
After I asked you for that last commit that disabled the X11 support for macOS, I thought of a better or more proper way to do it.
Also found one leftover xdnd code (unless I'm mistaken) and cleaned up (removed the commented) xdnd code.