### PR TITLE
Fixing Gimp 3 plugin issues

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -120,6 +120,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.sys }}
+          update: true
           install: |
             base-devel git zip
             ${{ matrix.env }}-toolchain ${{ matrix.env }}-binutils ${{ matrix.env }}-ntldd ${{ matrix.env }}-SDL2

--- a/.github/workflows/snapshots-windows.yml
+++ b/.github/workflows/snapshots-windows.yml
@@ -33,6 +33,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: MSYS
+          update: true
           install: |
             base-devel git p7zip zip
             mingw-w64-x86_64-toolchain mingw-w64-x86_64-binutils mingw-w64-x86_64-ntldd mingw-w64-x86_64-SDL2
@@ -103,7 +104,7 @@ jobs:
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/Exult.exe ./windows-snapshot
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/ExultStudio.exe ./windows-snapshot
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/ExultTools.exe ./windows-snapshot
-          cp ${{ env.EXULT_SNAPSHOT_PATH }}/Gimp20Plugin.exe ./windows-snapshot
+          cp ${{ env.EXULT_SNAPSHOT_PATH }}/Gimp30Plugin.exe ./windows-snapshot
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/Keyring.zip ./windows-snapshot
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/SFisland.zip ./windows-snapshot
           cp ${{ env.EXULT_SNAPSHOT_PATH }}/Sifixes.zip ./windows-snapshot

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -66,7 +66,7 @@ jobs:
             Exult.exe
             ExultStudio.exe
             ExultTools.exe
-            Gimp20Plugin.exe
+            Gimp30Plugin.exe
       - name: Generate VirusTotal Body
         if: ${{ (env.HAVE_WINDOWS_SNAPSHOT == 'true' && env.HAVE_ANDROID_SNAPSHOT == 'true')}}
         run: |
@@ -94,7 +94,7 @@ jobs:
             Exult.exe
             ExultStudio.exe
             ExultTools.exe
-            Gimp20Plugin.exe
+            Gimp30Plugin.exe
             Keyring.zip
             SFisland.zip
             Sifixes.zip

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -68,8 +68,6 @@ else
 	CXX:=g++
 endif
 
-
-
 ifdef USE_CONSOLE
 	SUBSYSTEM:=-mconsole
 	SYSFLAGS:=-DUSE_CONSOLE
@@ -139,14 +137,28 @@ GIMP3_INSTALLED:=$(shell pkg-config --silence-errors --cflags gimpui-3.0)
 GIMP2_INSTALLED:=$(shell pkg-config --silence-errors --cflags gimpui-2.0)
 ifneq ($(GIMP3_INSTALLED),$())
 PLUGIN_SRC:=u7shp
-GIMP_INCLUDES:=$(shell pkg-config --cflags gimpui-3.0 gtk+-3.0)
+GIMP_INCLUDES:=$(GIMP3_INSTALLED)
 GIMP_LIBS:=$(shell pkg-config --libs gimpui-3.0)
+IS_GIMP3:=1
 else
 ifneq ($(GIMP2_INSTALLED),$())
 PLUGIN_SRC:=u7shp-old
-GIMP_INCLUDES:=$(shell pkg-config --cflags gimpui-2.0 gtk+-2.0)
+GIMP_INCLUDES:=$(GIMP2_INSTALLED)
 GIMP_LIBS:=$(shell pkg-config --libs gimpui-2.0)
+IS_GIMP3:=0
 endif
+endif
+# libgexiv2 is for the Exiv2 metadata library. For some weird dumb reason, it is
+# including libstdc++ symbols at least in MinGW64 with GCC builds. This causes
+# linking errors in the plugin. We should probably file a bug upstream.
+# But in the mean time, we can work around the issue by removing it from the
+# list of libraries we link to, since we don't need any symbols from it.
+GIMP_LIBS:=$(subst -lgexiv2,,$(GIMP_LIBS))
+
+ifeq ($(GCC),g++)
+PLUGIN_NEEDS_LIBS:=$(IS_GIMP3)
+else
+PLUGIN_NEEDS_LIBS:=0
 endif
 
 ### Ogg vorbis inclides
@@ -572,7 +584,7 @@ mapedit/u7shp.o:
 	$(error Neither Gimp 3 nor Gimp 2 is installed, cannot build the Gimp plugin)
 endif
 u7shp$(EXEEXT) : mapedit/u7shp.o $(FILE_OBJS) shapes/vgafile.o imagewin/ibuf8.o imagewin/imagebuf.o
-	$(CXX) $(LDFLAGS) -static-libgcc -static-libstdc++ -o $(@) $+ $(GIMP_LIBS) -mwindows
+	$(CXX) $(LDFLAGS) -o $(@) $+ $(GIMP_LIBS) -mwindows
 
 install: $(EXEC)
 	mkdir -p $(U7PATH)
@@ -751,9 +763,13 @@ plugin: u7shp$(EXEEXT)
 plugininstall: plugin
 	mkdir -p $(GIMPPATH)
 	strip u7shp$(EXEEXT) -o $(GIMPPATH)/u7shp$(EXEEXT)
-	# Note: Gimp has everything a plugin needs already, so we don't
-	# need to ship anything else really.
+	# Note: Gimp has almost everything a plugin needs already, so we don't
+	# need to do this step.
 	#$(call copy_dlls_for_exe, u7shp$(EXEEXT), $(GIMPPATH))
+	# But we do need to do this for Gimp3.
+	if [ $(PLUGIN_NEEDS_LIBS) -ne 0 ]; then \
+		cp $(MSYSTEM_PREFIX)/bin/libgcc_s_seh-1.dll $(MSYSTEM_PREFIX)/libstdc++-6.dll $(GIMPPATH); \
+	fi
 
 plugindist: GIMPPATH:=$(DISTPATH)/GimpPlugin-$(MSYSTEM_CARCH)
 plugindist: plugin plugininstall

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -55,8 +55,8 @@ else ifeq ($(MSYSTEM),UCRT64)
 	CC:=gcc
 	CXX:=g++
 else ifeq ($(MSYSTEM),CLANGARM64)
-// march=native should not be used when building official releases
-// so if we start making official ARM build this needs to be changed
+# march=native should not be used when building official releases
+# so if we start making official ARM build this needs to be changed
 	ARCHTYPE:=-march=native
 	ARCHFLAGS:=-m64
 	CC:=clang
@@ -135,10 +135,19 @@ ES_INCLUDES:=$(GTK_INCLUDES) $(FREETYPE2_INCLUDES) $(ICU_INCLUDES)
 ES_LIBS:=$(GTK_LIBS) $(FREETYPE2_LIBS) $(ICU_LIBS) $(ZIP_LIBS) -lpng -luuid -lole32 -lwinmm -lws2_32 $(SUBSYSTEM)
 
 ### GIMP libs and includes, for the GIMP plugin.
-# If this doesn't work, insert output of 'gimptool --cflags' manually
+GIMP3_INSTALLED:=$(shell pkg-config --silence-errors --cflags gimpui-3.0)
+GIMP2_INSTALLED:=$(shell pkg-config --silence-errors --cflags gimpui-2.0)
+ifneq ($(GIMP3_INSTALLED),$())
+PLUGIN_SRC:=u7shp
+GIMP_INCLUDES:=$(shell pkg-config --cflags gimpui-3.0 gtk+-3.0)
+GIMP_LIBS:=$(shell pkg-config --libs gimpui-3.0)
+else
+ifneq ($(GIMP2_INSTALLED),$())
+PLUGIN_SRC:=u7shp-old
 GIMP_INCLUDES:=$(shell pkg-config --cflags gimpui-2.0 gtk+-2.0)
-# If this doesn't work, insert output of 'gimptool --libs' manually
 GIMP_LIBS:=$(shell pkg-config --libs gimpui-2.0)
+endif
+endif
 
 ### Ogg vorbis inclides
 OGG_INCLUDES:=$(shell pkg-config --cflags ogg vorbis vorbisfile)
@@ -555,10 +564,15 @@ exult_studio$(EXEEXT): $(BG_PAPERDOLL) $(FLEXES) $(ES_OBJS)
 exultstudioico.o: $(SRC)/win32/exultstudioico.rc $(SRC)/win32/exultstudio.ico win32/exult_studio.exe.manifest
 	windres --include-dir $(SRC)/win32 $(SRC)/win32/exultstudioico.rc $@
 
-mapedit/u7shp.o: CPPFLAGS:=$(PLUGIN_CPPFLAGS)
-
+ifneq ($(PLUGIN_SRC),$())
+mapedit/u7shp.o: mapedit/$(PLUGIN_SRC).cc
+	$(CXX) $(CXXFLAGS) $(PLUGIN_CPPFLAGS) -c -o $(@) mapedit/$(PLUGIN_SRC).cc
+else
+mapedit/u7shp.o:
+	$(error Neither Gimp 3 nor Gimp 2 is installed, cannot build the Gimp plugin)
+endif
 u7shp$(EXEEXT) : mapedit/u7shp.o $(FILE_OBJS) shapes/vgafile.o imagewin/ibuf8.o imagewin/imagebuf.o
-	$(CXX) $(LDFLAGS) -o $(@) $+ $(GIMP_LIBS) -mwindows
+	$(CXX) $(LDFLAGS) -static-libgcc -static-libstdc++ -o $(@) $+ $(GIMP_LIBS) -mwindows
 
 install: $(EXEC)
 	mkdir -p $(U7PATH)
@@ -748,7 +762,7 @@ plugindist: plugin plugininstall
 	u2d $(GIMPPATH)/*.txt
 	cp win32/exult_shpplugin_installer.iss $(DISTPATH)
 
-allclean: clean toolsclean studioclean modsclean
+allclean: clean toolsclean studioclean modsclean pluginclean
 	rm -f exconfig.dll exconfig_rc.o win32/exconfig.o
 	rm -f Exult\ Source\ Code.url
 

--- a/README.win32
+++ b/README.win32
@@ -94,9 +94,14 @@ To build Exult Studio, you must install the following:
             mingw-w64-${MSYSTEM_CARCH}-zlib \
             mingw-w64-${MSYSTEM_CARCH}-icu
 
-To build the Gimp Plug-In, you must install the following:
+To build the Gimp 2 Plug-In, you must install the following:
     pacman -S --noconfirm --needed \
             mingw-w64-${MSYSTEM_CARCH}-gtk2 \
+            mingw-w64-${MSYSTEM_CARCH}-gimp2
+
+To build the Gimp 3 Plug-In, you must install the following:
+    pacman -S --noconfirm --needed \
+            mingw-w64-${MSYSTEM_CARCH}-gtk3 \
             mingw-w64-${MSYSTEM_CARCH}-gimp
 
 You now have everything needed to build any of the components you want.
@@ -116,6 +121,8 @@ to be installed to. This depends on the version of Gimp you use:
         C:/Users/<username>/.gimp-2.8/plug-ins
     Gimp 2.10 and newer:
         C:/Users/<username>/AppData/Roaming/GIMP/<version>/plug-ins
+    Gimp 3.0 and newer:
+        C:/Users/<username>/AppData/Roaming/GIMP/<version>/plug-ins/u7shp
 
 If you are compiling Exult Studio, it will be installed to the same directory
 that Exult when you compile it. You can change that directory in the same way.

--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,7 @@ cxx_compilers="g++ clang++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC"
 
 # determine windowing system from 'host'
 AC_MSG_CHECKING([windowing system])
+HOME_DATADIR="${XDG_CONFIG_HOME:-${HOME}/.config}"
 case "$host_os" in
 	linux-android*)
 		# Android cross compiled from Linux, supported.
@@ -116,6 +117,7 @@ case "$host_os" in
 		SYSLIBS="-framework CoreFoundation -framework AudioUnit -framework AudioToolbox -framework CoreMIDI"
 		CXXFLAGS="$CXXFLAGS -stdlib=libc++ -pthread"
 		EXULT_DATADIR="/Library/Application\ Support/Exult/data"
+		HOME_DATADIR="${HOME}/Library/Application\ Support"
 		ARCH=macosx
 		dnl swap around clang for OSX
 		cxx_compilers="clang++ g++ c++ gpp aCC CC cxx cc++ cl.exe FCC KCC RCC xlC_r xlC"
@@ -903,35 +905,66 @@ else
 fi
 
 # GIMP plugin
-AM_CONDITIONAL(GIMP_PLUGIN, false)
-AC_ARG_ENABLE(gimp-plugin, AS_HELP_STRING([--enable-gimp-plugin], [Build the GIMP plugin @<:@default no@:>@]),,enable_gimp_plugin=no)
+AM_CONDITIONAL(GIMP3_PLUGIN, false)
+AM_CONDITIONAL(GIMP2_PLUGIN, false)
+AC_ARG_ENABLE(gimp-plugin,
+	AS_HELP_STRING([--enable-gimp-plugin@<:@=yes|system|user|no@:>@],
+		[Build the GIMP plugin, yes or system for system install (requires root), user for user install, @<:@default no@:>@]),,enable_gimp_plugin=no)
 AC_MSG_CHECKING([whether to build the GIMP plugin])
-if test x$enable_gimp_plugin = xyes; then
+if test x$enable_gimp_plugin != xno; then
 	AC_MSG_RESULT(yes)
-	AC_MSG_CHECKING([for gimptool])
-	AC_CHECK_PROGS(GIMPTOOL, gimptool-2.0)
-	if test -z "$GIMPTOOL"; then
-		AC_MSG_RESULT([no, not building GIMP plugin])
-	else
+	AC_CHECK_PROGS(GIMPTOOL, gimptool-3.0)
+	if test -n "$GIMPTOOL"; then
 		AC_MSG_CHECKING([for GIMP version])
 		gimp_version=`$GIMPTOOL --version`
-		AX_COMPARE_VERSION([$gimp_version], [ge], [2.8.0], [dnl
-			dnl $gimp_version >= 2.8.0
-			AC_MSG_RESULT([found $gimp_version >= 2.8.0])
+		AX_COMPARE_VERSION([$gimp_version], [ge], [3.0.0], [dnl
+			dnl $gimp_version >= 3.0.0
+			AC_MSG_RESULT([found $gimp_version >= 3.0.0])
 			AC_SUBST(GIMPTOOL)
-			AM_CONDITIONAL(GIMP_PLUGIN, true)
-			GIMP_PLUGIN_PREFIX=`$GIMPTOOL --gimpplugindir`
+			AM_CONDITIONAL(GIMP3_PLUGIN, true)
+			AS_IF([test x$enable_gimp_plugin != xuser],
+				[GIMP_PLUGIN_PREFIX=`$GIMPTOOL --gimpplugindir`],
+				[GIMP_PLUGIN_PREFIX="${HOME_DATADIR}/GIMP/3.0"])
 			GIMP_PLUGIN_PREFIX="$GIMP_PLUGIN_PREFIX/plug-ins"
 			AC_SUBST(GIMP_PLUGIN_PREFIX)
 			AC_DEFINE(HAVE_GIMP, 1, [Have GIMP])
-			GIMP_INCLUDES=`$PKG_CONFIG --cflags gimpui-2.0`
-			GIMP_LIBS=`$PKG_CONFIG --libs gimpui-2.0`
+			GIMP_INCLUDES=`$PKG_CONFIG --cflags gimpui-3.0`
+			GIMP_LIBS=`$PKG_CONFIG --libs gimpui-3.0`
 			AC_SUBST(GIMP_INCLUDES)
 			AC_SUBST(GIMP_LIBS)
 		], [
-			dnl $gimp_version < 2.8.0
-			AC_MSG_RESULT([found $gimp_version < 2.8.0 - disabling plugin])
+			dnl $gimp_version < 3.0.0
+			AC_MSG_RESULT([found $gimp_version < 3.0.0 - disabling plugin])
 		])
+	else
+		AC_CHECK_PROGS(GIMPTOOL, gimptool-2.0)
+		if test -n "$GIMPTOOL"; then
+			AC_MSG_CHECKING([for GIMP 2 version])
+			gimp_version=`$GIMPTOOL --version`
+			AX_COMPARE_VERSION([$gimp_version], [ge], [2.8.0], [dnl
+				dnl $gimp_version >= 2.8.0
+				AC_MSG_RESULT([found $gimp_version >= 2.8.0])
+				AC_SUBST(GIMPTOOL)
+				AM_CONDITIONAL(GIMP2_PLUGIN, true)
+				AS_IF([test x$enable_gimp_plugin != xuser],
+					[GIMP_PLUGIN_PREFIX=`$GIMPTOOL --gimpplugindir`],
+					[GIMP_PLUGIN_PREFIX="${HOME_DATADIR}/GIMP/2.0"])
+				GIMP_PLUGIN_PREFIX="$GIMP_PLUGIN_PREFIX/plug-ins"
+				AC_SUBST(GIMP_PLUGIN_PREFIX)
+				AC_DEFINE(HAVE_GIMP, 1, [Have GIMP])
+				GIMP_INCLUDES=`$PKG_CONFIG --cflags gimpui-2.0`
+				GIMP_LIBS=`$PKG_CONFIG --libs gimpui-2.0`
+				AC_SUBST(GIMP_INCLUDES)
+				AC_SUBST(GIMP_LIBS)
+			], [
+				dnl $gimp_version < 2.8.0
+				AC_MSG_RESULT([found $gimp_version < 2.8.0 - disabling plugin])
+			])
+		else
+			echo "The Gimp plugin requires the Gimp either in version 3 or in version 2, but neither is installed."
+			echo "Please try again, either with the Gimp installed, or with '--disable-gimp-plugin'."
+			exit 1
+		fi
 	fi
 else
 	AC_MSG_RESULT(no)
@@ -1397,6 +1430,9 @@ else
 	fi
 	if test x$enable_gnome_shp_thumbnailer = xyes; then
 		echo GDK-Pixbuf................. : `$PKG_CONFIG --modversion gdk-pixbuf-2.0`
+	fi
+	if test -n "$GIMPTOOL"; then
+		echo GIMP....................... : `$GIMPTOOL --version`
 	fi
 	echo
 fi

--- a/mapedit/Makefile.am
+++ b/mapedit/Makefile.am
@@ -5,19 +5,25 @@ AM_CPPFLAGS = -I$(top_srcdir)/headers -I$(top_srcdir) -I$(top_srcdir)/shapes \
 	$(GTK_CFLAGS) $(PNG_CFLAGS) $(ICU_CFLAGS) $(INCDIRS) $(WINDOWING_SYSTEM) \
 	$(DEBUG_LEVEL) $(OPT_LEVEL) $(WARNINGS) $(CPPFLAGS) -DEXULT_DATADIR=\"$(EXULT_DATADIR)\"
 
-if GIMP_PLUGIN
-GIMP_PLUGINS=u7shp
+if GIMP3_PLUGIN
+GIMP_PLUGIN_SRC = u7shp
+GIMP_PLUGINS = u7shp
 else
-GIMP_PLUGINS=
+if GIMP2_PLUGIN
+GIMP_PLUGIN_SRC = u7shp-old
+GIMP_PLUGINS = u7shp
+else
+GIMP_PLUGINS =
+endif
 endif
 
 if BUILD_STUDIO
-bin_PROGRAMS = exult_studio
+bin_PROGRAMS = exult_studio $(GIMP_PLUGINS)
 else
-bin_PROGRAMS =
+bin_PROGRAMS = $(GIMP_PLUGINS)
 endif
 
-u7shp_SOURCES = u7shp.cc
+u7shp_SOURCES = $(GIMP_PLUGIN_SRC).cc
 
 u7shp_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/files -I$(top_srcdir)/headers \
 	-I$(top_srcdir)/shapes -I$(top_srcdir)/imagewin -I$(top_srcdir)/files \
@@ -101,12 +107,18 @@ EXTRA_DIST=	\
 	uniquepal.c \
 	logo.xpm
 
-if GIMP_PLUGIN
+if GIMP3_PLUGIN
+install-exec-local:
+	install -d $(DESTDIR)$(GIMP_PLUGIN_PREFIX)/u7shp
+	install -c $(GIMP_PLUGINS) $(DESTDIR)$(GIMP_PLUGIN_PREFIX)/u7shp
+else
+if GIMP2_PLUGIN
 install-exec-local:
 	install -d $(DESTDIR)$(GIMP_PLUGIN_PREFIX)
 	install -c $(GIMP_PLUGINS) $(DESTDIR)$(GIMP_PLUGIN_PREFIX)
 else
 install-exec-local:
+endif
 endif
 
 CLEANFILES = *~ u7shp$(EXEEXT)

--- a/mapedit/gimpwin32.txt
+++ b/mapedit/gimpwin32.txt
@@ -1,16 +1,22 @@
 The GIMP shapes plug-in
 =======================
 
-This Plug-In is for the Windows Port of The Gimp. It is tested with the latest version (2.8.14).
+This Plug-In is for the Windows Port of The Gimp. It is tested with the latest version of Gimp 2 (2.8.14) and Gimp 3 (3.0)
 With it you can edit *.shp files used by Exult and the original Ultima VII. This shapes are compressed into *.flx or *.vga files. Use expack from our tools download to extract the files.
 
 Get the installer for The Gimp at http://www.gimp.org/downloads/
 
-Install
-=======
+Install for Gimp 2
+==================
 
 - Install the Gimp (example: C:\Program Files\GIMP 2)
 - execute Gimp20Plugin.exe and choose C:\Program Files\GIMP 2\lib\gimp\2.0\plug-ins (if you installed the Gimp somewhere else, change accordingly) for extract path. If you extracted the file to some other directory copy u7shp.exe into that directory
+
+Install for Gimp 3
+==================
+
+- Install the Gimp (example: C:\Program Files\GIMP 3)
+- execute Gimp20Plugin.exe and choose C:\Program Files\GIMP 3\lib\gimp\3.0\plug-ins\u7shp (if you installed the Gimp somewhere else, change accordingly) for extract path. If you extracted the file to some other directory copy u7shp.exe into that directory
 
 
 Usage

--- a/mapedit/u7shp-old.cc
+++ b/mapedit/u7shp-old.cc
@@ -1,9 +1,9 @@
 /*
- * SHP loading file filter for The GIMP version 3.x.
+ * SHP loading file filter for The GIMP version 2.x.
  *
  * (C) 2000-2001 Tristan Tarrant
  * (C) 2001-2004 Willem Jan Palenstijn
- * (C) 2010-2025 The Exult Team
+ * (C) 2010-2022 The Exult Team
  *
  * You can find the most recent version of this file in the Exult sources,
  * available from https://exult.info/
@@ -13,16 +13,10 @@
 #	include "config.h"
 #endif
 
-/*
- * GIMP Side of the Shape load / export plugin
- */
-
 #ifdef __GNUC__
 #	pragma GCC diagnostic push
 #	pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #	pragma GCC diagnostic ignored "-Wold-style-cast"
-#	pragma GCC diagnostic ignored "-Wvariadic-macros"
-#	pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #	if !defined(__llvm__) && !defined(__clang__)
 #		pragma GCC diagnostic ignored "-Wpedantic"
 #		pragma GCC diagnostic ignored "-Wuseless-cast"
@@ -44,7 +38,6 @@
 #	define GDK_DISABLE_DEPRECATION_WARNINGS
 #	define GLIB_DISABLE_DEPRECATION_WARNINGS
 #endif    // USE_STRICT_GTK
-#include <glib/gstdio.h>
 #include <gtk/gtk.h>
 #include <libgimp/gimp.h>
 #include <libgimp/gimpui.h>
@@ -59,236 +52,23 @@
 #include "ignore_unused_variable_warning.h"
 #include "vgafile.h"
 
-#include <cerrno>
 #include <iostream>
 #include <string>
 #include <vector>
 
-/*
- * GIMP Side of the Shape load / export plugin
- *   Borrowed from plug-ins/common/file-cel.c
- *      -- KISS CEL file format plug-in
- *      -- (copyright) 1997,1998 Nick Lamb (njl195@zepler.org.uk)
+/* Declare some local functions.
  */
-
-#define LOAD_PROC      "file-shp-load"
-#define EXPORT_PROC    "file-shp-export"
-#define PLUG_IN_BINARY "file-shp"
-#define PLUG_IN_ROLE   "gimp-file-shp"
-
-using Shp      = struct _Shp;
-using ShpClass = struct _ShpClass;
-
-struct _Shp {
-	GimpPlugIn parent_instance;
-};
-
-struct _ShpClass {
-	GimpPlugInClass parent_class;
-};
-
-#define SHP_TYPE (shp_get_type())
-#define SHP(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), SHP_TYPE, Shp))
-
-GType shp_get_type(void) G_GNUC_CONST;
-
-static GList*         shp_query_procedures(GimpPlugIn* plug_in);
-static GimpProcedure* shp_create_procedure(
-		GimpPlugIn* plug_in, const gchar* name);
-
-static GimpValueArray* shp_load(
-		GimpProcedure* procedure, GimpRunMode run_mode, GFile* file,
-		GimpMetadata* metadata, GimpMetadataLoadFlags* flags,
-		GimpProcedureConfig* config, gpointer run_data);
-static GimpValueArray* shp_export(
-		GimpProcedure* procedure, GimpRunMode run_mode, GimpImage* image,
-		GFile* file, GimpExportOptions* options, GimpMetadata* metadata,
-		GimpProcedureConfig* config, gpointer run_data);
-static gboolean shp_palette_dialog(
-		const gchar* title, GimpProcedure* procedure,
-		GimpProcedureConfig* config);
-
-static gint       load_palette(GFile* file, guchar palette[], GError** error);
-static GimpImage* load_image(
-		GFile* file, GFile* palette_file, GimpRunMode run_mode, GError** error);
-static gboolean export_image(
-		GFile* file, GimpImage* image, GimpRunMode run_mode, GError** error);
-
-#ifdef __GNUC__
-#	pragma GCC diagnostic push
-#	pragma GCC diagnostic ignored "-Wold-style-cast"
-#	if defined(__llvm__) || defined(__clang__)
-#		if __clang_major__ >= 16
-#			pragma GCC diagnostic ignored "-Wcast-function-type-strict"
-#		endif
-#	endif
-#endif    // __GNUC__
-G_DEFINE_TYPE(Shp, shp, GIMP_TYPE_PLUG_IN)
-#ifdef __GNUC__
-#	pragma GCC diagnostic pop
-#endif    // __GNUC__
-
-GIMP_MAIN(SHP_TYPE)
-
-static void shp_class_init(ShpClass* klass) {
-	GimpPlugInClass* plug_in_class  = GIMP_PLUG_IN_CLASS(klass);
-	plug_in_class->query_procedures = shp_query_procedures;
-	plug_in_class->create_procedure = shp_create_procedure;
-	plug_in_class->set_i18n         = nullptr;
-}
-
-static void shp_init(Shp* shp) {
-	ignore_unused_variable_warning(shp);
-}
-
-static GList* shp_query_procedures(GimpPlugIn* plug_in) {
-	ignore_unused_variable_warning(plug_in);
-	GList* list = nullptr;
-	list        = g_list_append(list, g_strdup(LOAD_PROC));
-	list        = g_list_append(list, g_strdup(EXPORT_PROC));
-	return list;
-}
-
-static GimpProcedure* shp_create_procedure(
-		GimpPlugIn* plug_in, const gchar* name) {
-	GimpProcedure* procedure = nullptr;
-	if (!strcmp(name, LOAD_PROC)) {
-		procedure = gimp_load_procedure_new(
-				plug_in, name, GIMP_PDB_PROC_TYPE_PLUGIN, shp_load, nullptr,
-				nullptr);
-		gimp_procedure_set_menu_label(procedure, "Ultima VII Shape");
-		gimp_procedure_set_documentation(
-				procedure, "Loads files in Ultima VII Shape file format",
-				"This plug-in loads individual Ultima VII "
-				"Shape files.",
-				name);
-		gimp_procedure_set_attribution(
-				procedure, "The Exult Team", "The Exult Team", "2010-2025");
-		gimp_file_procedure_set_extensions(
-				GIMP_FILE_PROCEDURE(procedure), "shp");
-		gimp_procedure_add_file_argument(
-				procedure, "palette-file", "_Palette file",
-				"PAL file to load palette from", GIMP_FILE_CHOOSER_ACTION_OPEN,
-				TRUE, nullptr, G_PARAM_READWRITE);
-	} else if (!strcmp(name, EXPORT_PROC)) {
-		procedure = gimp_export_procedure_new(
-				plug_in, name, GIMP_PDB_PROC_TYPE_PLUGIN, FALSE, shp_export,
-				nullptr, nullptr);
-		gimp_procedure_set_image_types(procedure, "RGB*, INDEXED*");
-		gimp_procedure_set_menu_label(procedure, "Ultima VII Shape");
-		gimp_procedure_set_documentation(
-				procedure, "Exports files in Ultima VII Shape file format",
-				"This plug-in exports individual Ultima VII "
-				"Shape files.",
-				name);
-		gimp_procedure_set_attribution(
-				procedure, "The Exult Team", "The Exult Team", "2010-2025");
-		gimp_file_procedure_set_handles_remote(
-				GIMP_FILE_PROCEDURE(procedure), TRUE);
-		gimp_file_procedure_set_extensions(
-				GIMP_FILE_PROCEDURE(procedure), "shp");
-		gimp_export_procedure_set_capabilities(
-				GIMP_EXPORT_PROCEDURE(procedure),
-				static_cast<GimpExportCapabilities>(
-						GIMP_EXPORT_CAN_HANDLE_RGB
-						| GIMP_EXPORT_CAN_HANDLE_ALPHA
-						| GIMP_EXPORT_CAN_HANDLE_LAYERS
-						| GIMP_EXPORT_CAN_HANDLE_INDEXED),
-				nullptr, nullptr, nullptr);
-		gimp_procedure_add_file_argument(
-				procedure, "palette-file", "_Palette file",
-				"PAL file to save palette to", GIMP_FILE_CHOOSER_ACTION_OPEN,
-				TRUE, nullptr, G_PARAM_READWRITE);
-	}
-	return procedure;
-}
-
-static GimpValueArray* shp_load(
-		GimpProcedure* procedure, GimpRunMode run_mode, GFile* file,
-		GimpMetadata* metadata, GimpMetadataLoadFlags* flags,
-		GimpProcedureConfig* config, gpointer run_data) {
-	ignore_unused_variable_warning(
-			procedure, run_mode, file, metadata, flags, config, run_data);
-	GimpValueArray* return_vals;
-	GimpImage*      image        = nullptr;
-	GFile*          palette_file = nullptr;
-	GError*         error        = nullptr;
-
-	gegl_init(nullptr, nullptr);
-
-	if (error != nullptr) {
-		return gimp_procedure_new_return_values(
-				procedure, GIMP_PDB_EXECUTION_ERROR, error);
-	}
-
-	g_object_get(config, "palette-file", &palette_file, nullptr);
-	if (run_mode != GIMP_RUN_NONINTERACTIVE) {
-		if (!shp_palette_dialog("Load PAL Palette", procedure, config)) {
-			return gimp_procedure_new_return_values(
-					procedure, GIMP_PDB_CANCEL, nullptr);
-		}
-		g_clear_object(&palette_file);
-		g_object_get(config, "palette-file", &palette_file, nullptr);
-	}
-
-	image = load_image(file, palette_file, run_mode, &error);
-	g_clear_object(&palette_file);
-	if (!image) {
-		return gimp_procedure_new_return_values(
-				procedure, GIMP_PDB_EXECUTION_ERROR, error);
-	}
-	return_vals = gimp_procedure_new_return_values(
-			procedure, GIMP_PDB_SUCCESS, nullptr);
-	GIMP_VALUES_SET_IMAGE(return_vals, 1, image);
-	return return_vals;
-}
-
-static GimpValueArray* shp_export(
-		GimpProcedure* procedure, GimpRunMode run_mode, GimpImage* image,
-		GFile* file, GimpExportOptions* options, GimpMetadata* metadata,
-		GimpProcedureConfig* config, gpointer run_data) {
-	ignore_unused_variable_warning(
-			procedure, run_mode, image, file, options, metadata, config,
-			run_data);
-	GimpPDBStatusType status = GIMP_PDB_SUCCESS;
-	GimpExportReturn  expret = GIMP_EXPORT_IGNORE;
-	GError*           error  = nullptr;
-
-	gegl_init(nullptr, nullptr);
-
-	expret = gimp_export_options_get_image(options, &image);
-
-	if (!export_image(file, image, run_mode, &error)) {
-		status = GIMP_PDB_EXECUTION_ERROR;
-	}
-
-	if (expret == GIMP_EXPORT_EXPORT) {
-		gimp_image_delete(image);
-	}
-
-	return gimp_procedure_new_return_values(procedure, status, error);
-}
-
-static gboolean shp_palette_dialog(
-		const gchar* title, GimpProcedure* procedure,
-		GimpProcedureConfig* config) {
-	GtkWidget* dialog;
-	gboolean   run;
-
-	gimp_ui_init(PLUG_IN_BINARY);
-	dialog = gimp_procedure_dialog_new(
-			GIMP_PROCEDURE(procedure), GIMP_PROCEDURE_CONFIG(config), title);
-	gimp_procedure_dialog_set_ok_label(GIMP_PROCEDURE_DIALOG(dialog), "_Open");
-	gimp_procedure_dialog_fill(GIMP_PROCEDURE_DIALOG(dialog), nullptr);
-	run = gimp_procedure_dialog_run(GIMP_PROCEDURE_DIALOG(dialog));
-
-	gtk_widget_destroy(dialog);
-	return run;
-}
-
-/*
- * Exult Side of the Shape load / export plugin
- */
+static void query();
+static void run(
+		const gchar* name, gint nparams, const GimpParam* param,
+		gint* nreturn_vals, GimpParam** return_vals);
+static void   load_palette(const std::string& filename);
+static void   choose_palette();
+static gint32 load_image(gchar* filename);
+static gint32 save_image(
+		gchar* filename, gint32 image_ID, gint32 drawable_ID,
+		gint32 orig_image_ID);
+static GimpRunMode run_mode;
 
 static guchar gimp_cmap[768] = {
 		0x00, 0x00, 0x00, 0xF8, 0xF0, 0xCC, 0xF4, 0xE4, 0xA4, 0xF0, 0xDC, 0x78,
@@ -356,13 +136,129 @@ static guchar gimp_cmap[768] = {
 		0xFC, 0xFC, 0x00, 0x00, 0x00, 0xFF, 0x00, 0xFC, 0x00, 0xFC, 0x00, 0x00,
 		0xFC, 0xFC, 0xFC, 0x61, 0x61, 0x61, 0xC0, 0xC0, 0xC0, 0xFC, 0x00, 0xF1};
 
-static gint load_palette(GFile* file, guchar palette[], GError** error) {
-	ignore_unused_variable_warning(file, palette, error);
-	const U7object pal(gimp_file_get_utf8_name(file), 0);
+GimpPlugInInfo PLUG_IN_INFO = {
+		nullptr, /* init_proc  */
+		nullptr, /* quit_proc  */
+		query,   /* query_proc */
+		run,     /* run_proc   */
+};
+
+struct u7frame {
+	guchar* pixels;
+	size_t  datalen;
+	gint16  leftX;
+	gint16  leftY;
+	gint16  rightX;
+	gint16  rightY;
+	gint16  width;
+	gint16  height;
+};
+
+struct u7shape {
+	u7frame* frames;
+	size_t   num_frames;
+};
+
+MAIN()    // NOLINT
+
+static void query(void) {
+	constexpr static const GimpParamDef load_args[] = {
+			{ GIMP_PDB_INT32,     const_cast<gchar*>("run_mode"),
+			 const_cast<gchar*>("Interactive, non-interactive")},
+			{GIMP_PDB_STRING,     const_cast<gchar*>("filename"),
+			 const_cast<gchar*>("The name of the file to load")},
+			{GIMP_PDB_STRING, const_cast<gchar*>("raw_filename"),
+			 const_cast<gchar*>("The name entered")            }
+    };
+	constexpr static const GimpParamDef load_return_vals[] = {
+			{GIMP_PDB_IMAGE, const_cast<gchar*>("image"),
+			 const_cast<gchar*>("Output image")}
+    };
+	constexpr static const gint nload_args
+			= sizeof(load_args) / sizeof(load_args[0]);
+	constexpr static const gint nload_return_vals
+			= (sizeof(load_return_vals) / sizeof(load_return_vals[0]));
+
+	constexpr static const GimpParamDef save_args[] = {
+			{   GIMP_PDB_INT32,     const_cast<gchar*>("run_mode"),
+			 const_cast<gchar*>("Interactive, non-interactive")},
+			{   GIMP_PDB_IMAGE,        const_cast<gchar*>("image"),
+			 const_cast<gchar*>("Image to save")               },
+			{GIMP_PDB_DRAWABLE,     const_cast<gchar*>("drawable"),
+			 const_cast<gchar*>("Drawable to save")            },
+			{  GIMP_PDB_STRING,     const_cast<gchar*>("filename"),
+			 const_cast<gchar*>("The name of the file to save")},
+			{  GIMP_PDB_STRING, const_cast<gchar*>("raw_filename"),
+			 const_cast<gchar*>("The name entered")            }
+    };
+	constexpr static const gint nsave_args
+			= sizeof(save_args) / sizeof(save_args[0]);
+
+	gimp_install_procedure(
+			"file_shp_load", "loads files in Ultima VII SHP format",
+			"FIXME: write help for shp_load", "Tristan Tarrant",
+			"Tristan Tarrant", "2000", "<Load>/SHP", nullptr, GIMP_PLUGIN,
+			nload_args, nload_return_vals, load_args, load_return_vals);
+
+	gimp_register_magic_load_handler("file_shp_load", "shp", "", "");
+
+	gimp_install_procedure(
+			"file_shp_save", "Save files in Ultima VII SHP format",
+			"FIXME: write help for shp_save", "Tristan Tarrant",
+			"Tristan Tarrant", "2000", "<Save>/SHP", "INDEXEDA", GIMP_PLUGIN,
+			nsave_args, 0, save_args, nullptr);
+
+	gimp_register_save_handler("file_shp_save", "shp", "");
+}
+
+static void run(
+		const gchar* name, gint nparams, const GimpParam* param,
+		gint* nreturn_vals, GimpParam** return_vals) {
+	ignore_unused_variable_warning(nparams);
+	static GimpParam values[2];
+
+	gegl_init(nullptr, nullptr);
+
+	run_mode = static_cast<GimpRunMode>(param[0].data.d_int32);
+
+	*nreturn_vals           = 1;
+	*return_vals            = values;
+	values[0].type          = GIMP_PDB_STATUS;
+	values[0].data.d_status = GIMP_PDB_EXECUTION_ERROR;
+
+	GimpPDBStatusType status = GIMP_PDB_SUCCESS;
+	if (strcmp(name, "file_shp_load") == 0) {
+		gimp_ui_init("u7shp", false);
+		if (run_mode != GIMP_RUN_NONINTERACTIVE) {
+			choose_palette();
+		}
+		const gint32 image_ID = load_image(param[1].data.d_string);
+
+		if (image_ID != -1) {
+			*nreturn_vals          = 2;
+			values[1].type         = GIMP_PDB_IMAGE;
+			values[1].data.d_image = image_ID;
+		} else {
+			status = GIMP_PDB_EXECUTION_ERROR;
+		}
+	} else if (strcmp(name, "file_shp_save") == 0) {
+		const gint32 orig_image_ID = param[1].data.d_int32;
+		const gint32 image_ID      = orig_image_ID;
+		const gint32 drawable_ID   = param[2].data.d_int32;
+		save_image(
+				param[3].data.d_string, image_ID, drawable_ID, orig_image_ID);
+	} else {
+		status = GIMP_PDB_CALLING_ERROR;
+	}
+	values[0].data.d_status = status;
+}
+
+static void load_palette(const std::string& filename) {
+	const U7object pal(filename, 0);
 	size_t         len;
 	auto           data = pal.retrieve(len);
 	if (!data || len == 0) {
-		return 0;
+		return;
 	}
 	const auto* ptr = data.get();
 	if (len == 768) {
@@ -382,7 +278,32 @@ static gint load_palette(GFile* file, guchar palette[], GError** error) {
 			Read1(ptr);    // Skip entry from second palette
 		}
 	}
-	return 256;
+}
+
+std::string file_select(const gchar* title) {
+	GtkFileChooser* fsel = GTK_FILE_CHOOSER(gtk_file_chooser_dialog_new(
+			title, nullptr, GTK_FILE_CHOOSER_ACTION_OPEN, "_Cancel",
+			GTK_RESPONSE_CANCEL, "_Open", GTK_RESPONSE_ACCEPT, nullptr));
+	GtkWidget*      btn  = gtk_dialog_get_widget_for_response(
+            GTK_DIALOG(fsel), GTK_RESPONSE_CANCEL);
+	GtkWidget* img = gtk_image_new_from_icon_name(
+			"window-close", GTK_ICON_SIZE_BUTTON);
+	gtk_button_set_image(GTK_BUTTON(btn), img);
+	btn = gtk_dialog_get_widget_for_response(
+			GTK_DIALOG(fsel), GTK_RESPONSE_ACCEPT);
+	img = gtk_image_new_from_icon_name("document-open", GTK_ICON_SIZE_BUTTON);
+	gtk_button_set_image(GTK_BUTTON(btn), img);
+	gtk_window_set_modal(GTK_WINDOW(fsel), true);
+	if (gtk_dialog_run(GTK_DIALOG(fsel)) == GTK_RESPONSE_ACCEPT) {
+		std::string filename(gtk_file_chooser_get_filename(fsel));
+		return filename;
+	} else {
+		return "";
+	}
+}
+
+static void choose_palette() {
+	load_palette(file_select("Choose palette"));
 }
 
 struct Bounds {
@@ -407,25 +328,11 @@ Bounds get_shape_bounds(Shape_file& shape) {
 	return Bounds{7, 0, 0, 7};
 }
 
-/* Load Shape image into GIMP */
-
-static GimpImage* load_image(
-		GFile* file, GFile* palette_file, GimpRunMode run_mode,
-		GError** error) {
-	ignore_unused_variable_warning(file, palette_file, run_mode, error);
-	if (!g_file_query_exists(file, nullptr)) {
-		return nullptr;
-	}
-	Shape_file shape(gimp_file_get_utf8_name(file));
-	if (shape.get_num_frames() == 0) {
-		return nullptr;
-	}
+static gint32 load_image(gchar* filename) {
+	Shape_file shape(filename);
 #ifdef DEBUG
 	std::cout << "num_frames = " << shape.get_num_frames() << '\n';
 #endif
-	if (palette_file) {
-		load_palette(palette_file, nullptr, error);
-	}
 	const Bounds  bounds = get_shape_bounds(shape);
 	GimpImageType image_type;
 	if (shape.is_rle()) {
@@ -434,25 +341,23 @@ static GimpImage* load_image(
 		image_type = GIMP_INDEXED_IMAGE;
 	}
 
-	GimpImage* image = gimp_image_new(
+	const gint32 image_ID = gimp_image_new(
 			bounds.xleft + bounds.xright + 1, bounds.yabove + bounds.ybelow + 1,
 			GIMP_INDEXED);
-	gimp_palette_set_colormap(
-			gimp_image_get_palette(image), babl_format("R'G'B' u8"), gimp_cmap,
-			256 * 3);
+	gimp_image_set_filename(image_ID, filename);
+	gimp_image_set_colormap(image_ID, gimp_cmap, 256);
 	int framenum = 0;
 	for (auto& frame : shape) {
 		const std::string framename = "Frame " + std::to_string(framenum);
-		GimpLayer*        layer     = gimp_layer_new(
-                image, framename.c_str(), frame->get_width(),
-                frame->get_height(), image_type, 100,
-                gimp_image_get_default_new_layer_mode(image));
-		gimp_image_insert_layer(image, layer, nullptr, 0);
+		const gint32      layer_ID  = gimp_layer_new(
+                image_ID, framename.c_str(), frame->get_width(),
+                frame->get_height(), image_type, 100, GIMP_NORMAL_MODE);
+		gimp_image_insert_layer(image_ID, layer_ID, -1, 0);
 		gimp_item_transform_translate(
-				GIMP_ITEM(layer), bounds.xleft - frame->get_xleft(),
+				layer_ID, bounds.xleft - frame->get_xleft(),
 				bounds.yabove - frame->get_yabove());
 
-		GeglBuffer* drawable = gimp_drawable_get_buffer(GIMP_DRAWABLE(layer));
+		GeglBuffer*         drawable = gimp_drawable_get_buffer(layer_ID);
 		const GeglRectangle rect{
 				0, 0, gegl_buffer_get_width(drawable),
 				gegl_buffer_get_height(drawable)};
@@ -487,22 +392,23 @@ static GimpImage* load_image(
 		framenum++;
 	}
 
-	gimp_image_add_hguide(image, bounds.yabove);
-	gimp_image_add_vguide(image, bounds.xleft);
+	gimp_image_add_hguide(image_ID, bounds.yabove);
+	gimp_image_add_vguide(image_ID, bounds.xleft);
 #ifdef DEBUG
 	std::cout << "Added hguide=" << bounds.yabove << '\n'
 			  << "Added vguide=" << bounds.xleft << '\n';
 #endif
 
-	return image;
+	return image_ID;
 }
 
-static gboolean export_image(
-		GFile* file, GimpImage* image, GimpRunMode run_mode, GError** error) {
-	ignore_unused_variable_warning(file, image, run_mode, error);
+static gint32 save_image(
+		gchar* filename, gint32 image_ID, gint32 drawable_ID,
+		gint32 orig_image_ID) {
+	ignore_unused_variable_warning(drawable_ID, orig_image_ID);
 	if (run_mode != GIMP_RUN_NONINTERACTIVE) {
 		std::string name_buf("Saving ");
-		name_buf += gimp_file_get_utf8_name(file);
+		name_buf += filename;
 		name_buf += ':';
 		gimp_progress_init(name_buf.c_str());
 	}
@@ -510,16 +416,17 @@ static gboolean export_image(
 	// Find the guides...
 	int hotx = -1;
 	int hoty = -1;
-	for (gint32 guide_ID = gimp_image_find_next_guide(image, 0); guide_ID > 0;
-		 guide_ID        = gimp_image_find_next_guide(image, guide_ID)) {
+	for (gint32 guide_ID = gimp_image_find_next_guide(image_ID, 0);
+		 guide_ID > 0;
+		 guide_ID = gimp_image_find_next_guide(image_ID, guide_ID)) {
 #ifdef DEBUG
 		std::cout << "Found guide " << guide_ID << ':';
 #endif
 
-		switch (gimp_image_get_guide_orientation(image, guide_ID)) {
+		switch (gimp_image_get_guide_orientation(image_ID, guide_ID)) {
 		case GIMP_ORIENTATION_HORIZONTAL:
 			if (hoty < 0) {
-				hoty = gimp_image_get_guide_position(image, guide_ID);
+				hoty = gimp_image_get_guide_position(image_ID, guide_ID);
 #ifdef DEBUG
 				std::cout << " horizontal=" << hoty << '\n';
 #endif
@@ -527,7 +434,7 @@ static gboolean export_image(
 			break;
 		case GIMP_ORIENTATION_VERTICAL:
 			if (hotx < 0) {
-				hotx = gimp_image_get_guide_position(image, guide_ID);
+				hotx = gimp_image_get_guide_position(image_ID, guide_ID);
 #ifdef DEBUG
 				std::cout << " vertical=" << hotx << '\n';
 #endif
@@ -538,25 +445,22 @@ static gboolean export_image(
 		}
 	}
 
-	GList* layers  = g_list_reverse(gimp_image_list_layers(image));
-	gint32 nlayers = g_list_length(layers);
-	std::cout << "SHP: Exporting " << g_list_length(layers) << " layers"
-			  << std::endl;
+	// get a list of layers for this image_ID
+	int     nlayers;
+	gint32* layers = gimp_image_get_layers(image_ID, &nlayers);
 
-	if (layers && !gimp_drawable_is_indexed(GIMP_DRAWABLE(layers->data))) {
+	if (nlayers > 0 && !gimp_drawable_is_indexed(layers[0])) {
 		g_message("SHP: You can only save indexed images!");
-		return FALSE;
+		return -1;
 	}
 
-	Shape  shape(nlayers);
-	GList* cur_layer = g_list_first(layers);
+	Shape shape(nlayers);
+	int   layer = nlayers - 1;
 	for (auto& frame : shape) {
-		GeglBuffer* drawable
-				= gimp_drawable_get_buffer(GIMP_DRAWABLE(cur_layer->data));
-		gint offsetX;
-		gint offsetY;
-		gimp_drawable_get_offsets(
-				GIMP_DRAWABLE(cur_layer->data), &offsetX, &offsetY);
+		GeglBuffer* drawable = gimp_drawable_get_buffer(layers[layer]);
+		gint        offsetX;
+		gint        offsetY;
+		gimp_drawable_offsets(layers[layer], &offsetX, &offsetY);
 		const int    width           = gegl_buffer_get_width(drawable);
 		const int    height          = gegl_buffer_get_height(drawable);
 		const int    xleft           = hotx - offsetX;
@@ -587,16 +491,15 @@ static gboolean export_image(
 		}
 		frame = std::make_unique<Shape_frame>(
 				outptr, width, height, xleft, yabove, has_alpha);
-		cur_layer = g_list_next(cur_layer);
+		layer--;
 	}
 
-	OFileDataSource ds(gimp_file_get_utf8_name(file));
+	OFileDataSource ds(filename);
 	if (!ds.good()) {
-		g_message("SHP: can't create \"%s\"\n", gimp_file_get_utf8_name(file));
+		g_message("SHP: can't create \"%s\"\n", filename);
 		return -1;
 	}
 	shape.write(ds);
-	g_list_free(layers);
 
-	return TRUE;
+	return 0;
 }

--- a/win32/exult_shpplugin_installer.iss
+++ b/win32/exult_shpplugin_installer.iss
@@ -30,11 +30,11 @@ AppSupportURL=https://exult.info/
 AppUpdatesURL=https://exult.info/
 ; Setup exe version number:
 VersionInfoVersion=1.11.0
-DisableDirPage=no
-DefaultDirName={code:GetGimpDir|{pf}\GIMP 2}
+DisableDirPage=yes
+DefaultDirName="{userappdata}\gimp\3.0\plug-ins\u7shp"
 DisableProgramGroupPage=yes
 DefaultGroupName=Exult GIMP Plugin
-OutputBaseFilename=Gimp20Plugin
+OutputBaseFilename=Gimp30Plugin
 Compression=lzma
 SolidCompression=yes
 InternalCompressLevel=max
@@ -46,34 +46,19 @@ WizardStyle=modern
 CreateUninstallRegKey=no
 UpdateUninstallLogAppName=no
 AppID=GIMP-U7SHP-Plugin
-UninstallFilesDir={code:GetUninstallDir}
+PrivilegesRequired=none
 
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 ; 32-bit files
-Source: "GimpPlugin-i686\u7shp.exe"; DestDir: "{app}\lib\gimp\2.0\plug-ins"; Flags: ignoreversion; Check: not Is64BitGIMP
+Source: "GimpPlugin-i686\u7shp.exe"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: not Is64BitGIMP
 ; 64-bit files
-Source: "GimpPlugin-x86_64\u7shp.exe"; DestDir: "{app}\lib\gimp\2.0\plug-ins"; Flags: ignoreversion; Check: Is64BitGIMP
+Source: "GimpPlugin-x86_64\u7shp.exe"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: Is64BitGIMP
 
 [Code]
-function SHAutoComplete(hWnd: Integer; dwFlags: DWORD): Integer; external 'SHAutoComplete@shlwapi.dll stdcall delayload';
-
-function WideCharToMultiByte(CodePage: Cardinal; dwFlags: DWORD; lpWideCharStr: String; cchWideCharStr: Integer;
-							 lpMultiByteStr: PAnsiChar; cbMultiByte: Integer; lpDefaultChar: Integer;
-							 lpUsedDefaultChar: Integer): Integer; external 'WideCharToMultiByte@Kernel32 stdcall';
-
-function MultiByteToWideChar(CodePage: Cardinal; dwFlags: DWORD; lpMultiByteStr: PAnsiChar; cbMultiByte: Integer;
-							 lpWideCharStr: String; cchWideChar: Integer): Integer;
-							 external 'MultiByteToWideChar@Kernel32 stdcall';
-
-function GetLastError(): DWORD; external 'GetLastError@Kernel32 stdcall';
-
 const
-	SHACF_FILESYSTEM = $1;
-	CP_UTF8 = 65001;
-
-	RegPath = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\WinGimp-2.0_is1';
-	RegPathNew = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GIMP-2_is1';
+	RegPath = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\WinGimp-3.0_is1';
+	RegPathNew = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GIMP-3_is1';
 	RegKey = 'Inno Setup: App Path';
 	VerKey = 'DisplayName';
 
@@ -83,183 +68,12 @@ var
 
 	InstallType: (itOld, itNew, itNew64);
 
-function Count(What, Where: String): Integer;
-begin
-	Result := 0;
-	if Length(What) = 0 then //nothing to count - should this throw an error?
-		exit;
-
-	while Pos(What,Where)>0 do
-	begin
-		Where := Copy(Where,Pos(What,Where)+Length(What),Length(Where));
-		Result := Result + 1;
-	end;
-end;
-
-
-//split text to array
-procedure Explode(var ADest: TArrayOfString; aText, aSeparator: String);
-var tmp: Integer;
-begin
-	if aSeparator='' then
-		exit;
-
-	SetArrayLength(ADest,Count(aSeparator,aText)+1)
-
-	tmp := 0;
-	repeat
-		if Pos(aSeparator,aText)>0 then
-		begin
-
-			ADest[tmp] := Copy(aText,1,Pos(aSeparator,aText)-1);
-			aText := Copy(aText,Pos(aSeparator,aText)+Length(aSeparator),Length(aText));
-			tmp := tmp + 1;
-
-		end else
-		begin
-
-			 ADest[tmp] := aText;
-			 aText := '';
-
-		end;
-	until Length(aText)=0;
-end;
-
-//compares two version numbers, returns -1 if vA is newer, 0 if both are identical, 1 if vB is newer
-function CompareVersion(vA,vB: String): Integer;
-var tmp: TArrayOfString;
-	verA,verB: Array of Integer;
-	i,len: Integer;
-begin
-
-	StringChange(vA,'-','.');
-	StringChange(vB,'-','.');
-
-	Explode(tmp,vA,'.');
-	SetArrayLength(verA,GetArrayLength(tmp));
-	for i := 0 to GetArrayLength(tmp) - 1 do
-		verA[i] := StrToIntDef(tmp[i],0);
-
-	Explode(tmp,vB,'.');
-	SetArrayLength(verB,GetArrayLength(tmp));
-	for i := 0 to GetArrayLength(tmp) - 1 do
-		verB[i] := StrToIntDef(tmp[i],0);
-
-	len := GetArrayLength(verA);
-	if GetArrayLength(verB) < len then
-		len := GetArrayLength(verB);
-
-	for i := 0 to len - 1 do
-		if verA[i] < verB[i] then
-		begin
-			Result := 1;
-			exit;
-		end else
-		if verA[i] > verB[i] then
-		begin
-			Result := -1;
-			exit
-		end;
-
-	if GetArrayLength(verA) < GetArrayLength(verB) then
-	begin
-		Result := 1;
-		exit;
-	end else
-	if GetArrayLength(verA) > GetArrayLength(verB) then
-	begin
-		Result := -1;
-		exit;
-	end;
-
-	Result := 0;
-end;
-
-function Utf82String(const pInput: AnsiString): String;
-#ifndef UNICODE
-	#error "Unicode Inno Setup required"
-#endif
-var Output: String;
-	ret, outLen, nulPos: Integer;
-begin
-	outLen := MultiByteToWideChar(CP_UTF8, 0, pInput, -1, Output, 0);
-	Output := StringOfChar(#0,outLen);
-	ret := MultiByteToWideChar(CP_UTF8, 0, pInput, -1, Output, outLen);
-
-	if ret = 0 then
-		RaiseException('MultiByteToWideChar failed: ' + IntToStr(GetLastError));
-
-	nulPos := Pos(#0,Output) - 1;
-	if nulPos = -1 then
-		nulPos := Length(Output);
-
-	Result := Copy(Output,1,nulPos);
-end;
-
-function LoadStringFromUTF8File(const pFileName: String; var oS: String): Boolean;
-var Utf8String: AnsiString;
-begin
-	Result := LoadStringFromFile(pFileName, Utf8String);
-	oS := Utf82String(Utf8String);
-end;
-
-function String2Utf8(const pInput: String): AnsiString;
-var Output: AnsiString;
-	ret, outLen, nulPos: Integer;
-begin
-	outLen := WideCharToMultiByte(CP_UTF8, 0, pInput, -1, Output, 0, 0, 0);
-	Output := StringOfChar(#0,outLen);
-	ret := WideCharToMultiByte(CP_UTF8, 0, pInput, -1, Output, outLen, 0, 0);
-
-	if ret = 0 then
-		RaiseException('WideCharToMultiByte failed: ' + IntToStr(GetLastError));
-
-	nulPos := Pos(#0,Output) - 1;
-	if nulPos = -1 then
-		nulPos := Length(Output);
-
-	Result := Copy(Output,1,nulPos);
-end;
-
-function SaveStringToUTF8File(const pFileName, pS: String; const pAppend: Boolean): Boolean;
-begin
-	Result := SaveStringToFile(pFileName, String2Utf8(pS), pAppend);
-end;
-
-procedure SaveToUninstInf(const pText: AnsiString);
-var sUnInf: String;
-	sOldContent: String;
-begin
-	sUnInf := ExpandConstant('{app}\uninst\uninst.inf');
-
-	if not FileExists(sUnInf) then //save small header
-		SaveStringToUTF8File(sUnInf,#$feff+'#Additional uninstall tasks'#13#10+ //#$feff BOM is required for LoadStringsFromFile
-									'#This file uses UTF-8 encoding'#13#10+
-									'#'#13#10+
-									'#Empty lines and lines beginning with # are ignored'#13#10+
-									'#'#13#10+
-									'#Add uninstallers for GIMP add-ons that should be removed together with GIMP like this:'#13#10+
-									'#Run:<description>/<full path to uninstaller>/<parameters for automatic uninstall>'#13#10+
-									'#'#13#10+
-									'#The file is parsed in reverse order' + #13#10 +
-									'' + #13#10 //needs '' in front, otherwise preprocessor complains
-									,False)
-	else
-	begin
-		if LoadStringFromUTF8File(sUnInf,sOldContent) then
-			if Pos(#13#10+pText+#13#10,sOldContent) > 0 then //don't write duplicate lines
-				exit;
-	end;
-
-	SaveStringToUTF8File(sUnInf,pText+#13#10,True);
-end;
-
 procedure GetGimpInfo(const pRootKey: Integer; const pRegPath: String);
 var p: Integer;
 begin
 	If not RegQueryStringValue(pRootKey, pRegPath, RegKey, GimpPath) then //find Gimp install dir
 	begin
-		GimpPath := ExpandConstant('{pf}\GIMP 2');
+		GimpPath := ExpandConstant('{pf}\GIMP 3');
 	end;
 
 	If not RegQueryStringValue(pRootKey, pRegPath, VerKey, GimpVer) then //find Gimp version
@@ -277,11 +91,6 @@ begin
 	end;
 end;
 
-procedure WriteUninstallInfo();
-begin
-	if InstallType <> itOld then //new installer expects components to be listed in the uninst.inf file
-		SaveToUninstInf('Run:GIMP Help/'+ExpandConstant('{uninstallexe}')+'//SILENT /NORESTART');
-end;
 
 function InitializeSetup(): Boolean;
 begin
@@ -303,7 +112,7 @@ begin
 		InstallType := itOld;
 	end else
 	begin
-		GimpPath := ExpandConstant('{pf}\GIMP 2'); //provide some defaults
+		GimpPath := ExpandConstant('{pf}\GIMP 3'); //provide some defaults
 		GimpVer := '0';
 	end;
 end;
@@ -311,38 +120,4 @@ end;
 function Is64BitGIMP(): boolean;
 begin
 	Result := InstallType = itNew64;
-end;
-
-procedure CurStepChanged(pCurStep: TSetupStep);
-begin
-	case pCurStep of
-		ssPostInstall:
-		begin
-			WriteUninstallInfo();
-		end;
-	end;
-end;
-
-procedure InitializeWizard();
-var r: Integer;
-begin
-	r := SHAutoComplete(WizardForm.DirEdit.Handle,SHACF_FILESYSTEM);
-end;
-
-function GetGimpDir(S: String): String;
-begin
-	Result := GimpPath;
-end;
-
-function GetUninstallDir(default: String): String;
-begin
-	if CompareVersion(GimpVer,'2.10.0') >= 0 then
-		Result := ExpandConstant('{app}')
-	else
-	begin
-		if InstallType = itOld then
-			Result := ExpandConstant('{app}\setup')
-		else
-			Result := ExpandConstant('{app}\uninst');
-	end;
 end;

--- a/win32/exult_shpplugin_installer.iss
+++ b/win32/exult_shpplugin_installer.iss
@@ -52,8 +52,12 @@ PrivilegesRequired=none
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 ; 32-bit files
 Source: "GimpPlugin-i686\u7shp.exe"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: not Is64BitGIMP
+Source: "GimpPlugin-i686\libgcc_s_seh-1.dll"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: not Is64BitGIMP
+Source: "GimpPlugin-i686\libstdc++-6.dll"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: not Is64BitGIMP
 ; 64-bit files
 Source: "GimpPlugin-x86_64\u7shp.exe"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: Is64BitGIMP
+Source: "GimpPlugin-x86_64\libgcc_s_seh-1.dll"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: Is64BitGIMP
+Source: "GimpPlugin-x86_64\libstdc++-6.dll"; DestDir: "{userappdata}\gimp\3.0\plug-ins\u7shp"; Flags: ignoreversion; Check: Is64BitGIMP
 
 [Code]
 const


### PR DESCRIPTION
We don't need libgexiv2, and it is probably a bug that it includes (and shares) libstdc++ symbols anyway.

We also don't need to statically link anything and can just ship the libraries to the plugin directory.